### PR TITLE
Makefile: compile hook.c

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-OBJ=main.o ddhcp.o netsock.o packet.o dhcp.o dhcp_packet.o dhcp_options.o tools.o block.o control.o
-OBJCTL=ddhcpctl.o netsock.o packet.o dhcp.o dhcp_packet.o dhcp_options.o tools.o block.o
+OBJ=main.o ddhcp.o netsock.o packet.o dhcp.o dhcp_packet.o dhcp_options.o tools.o block.o control.o hook.o
+OBJCTL=ddhcpctl.o netsock.o packet.o dhcp.o dhcp_packet.o dhcp_options.o tools.o block.o hook.o
 
 REVISION=$(shell git rev-list --first-parent HEAD --max-count=1)
 


### PR DESCRIPTION
If not compiling breaks with the following error:

    a@flat ~/src/ddhcpd (master) $ make
    echo '#define REVISION "9fd32f274489fe6d3dd789e1afd5aa8c59f83a7f"' > version.h
    gcc -Wall -Wextra -pedantic -Werror -flto -fno-strict-aliasing -std=gnu11 -D_GNU_SOURCE -MD -MP -DNDEBUG   -c -o main.o main.c
    gcc -Wall -Wextra -pedantic -Werror -flto -fno-strict-aliasing -std=gnu11 -D_GNU_SOURCE -MD -MP -DNDEBUG   -c -o ddhcp.o ddhcp.c
    gcc -Wall -Wextra -pedantic -Werror -flto -fno-strict-aliasing -std=gnu11 -D_GNU_SOURCE -MD -MP -DNDEBUG   -c -o netsock.o netsock.c
    gcc -Wall -Wextra -pedantic -Werror -flto -fno-strict-aliasing -std=gnu11 -D_GNU_SOURCE -MD -MP -DNDEBUG   -c -o packet.o packet.c
    gcc -Wall -Wextra -pedantic -Werror -flto -fno-strict-aliasing -std=gnu11 -D_GNU_SOURCE -MD -MP -DNDEBUG   -c -o dhcp.o dhcp.c
    gcc -Wall -Wextra -pedantic -Werror -flto -fno-strict-aliasing -std=gnu11 -D_GNU_SOURCE -MD -MP -DNDEBUG   -c -o dhcp_packet.o dhcp_packet.c
    gcc -Wall -Wextra -pedantic -Werror -flto -fno-strict-aliasing -std=gnu11 -D_GNU_SOURCE -MD -MP -DNDEBUG   -c -o dhcp_options.o dhcp_options.c
    gcc -Wall -Wextra -pedantic -Werror -flto -fno-strict-aliasing -std=gnu11 -D_GNU_SOURCE -MD -MP -DNDEBUG   -c -o tools.o tools.c
    gcc -Wall -Wextra -pedantic -Werror -flto -fno-strict-aliasing -std=gnu11 -D_GNU_SOURCE -MD -MP -DNDEBUG   -c -o block.o block.c
    gcc -Wall -Wextra -pedantic -Werror -flto -fno-strict-aliasing -std=gnu11 -D_GNU_SOURCE -MD -MP -DNDEBUG   -c -o control.o control.c
    gcc main.o ddhcp.o netsock.o packet.o dhcp.o dhcp_packet.o dhcp_options.o tools.o block.o control.o -Wall -Wextra -pedantic -Werror -flto -fno-strict-aliasing -std=gnu11 -D_GNU_SOURCE -MD -MP -DNDEBUG -o ddhcpd -flto -lm
    /tmp/cc7Wjp4Y.ltrans0.ltrans.o: In function `dhcp_hdl_release':
    <artificial>:(.text+0x3bca): undefined reference to `hook'
    /tmp/cc7Wjp4Y.ltrans0.ltrans.o: In function `dhcp_ack':
    <artificial>:(.text+0x3e01): undefined reference to `hook'
    collect2: error: ld returned 1 exit status
    make: *** [Makefile:47: ddhcpd] Error 1