### PR TITLE
[RFC] Add dynamic runtime verbosity selection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-OBJ=main.o ddhcp.o netsock.o packet.o dhcp.o dhcp_packet.o dhcp_options.o tools.o block.o control.o hook.o
-OBJCTL=ddhcpctl.o netsock.o packet.o dhcp.o dhcp_packet.o dhcp_options.o tools.o block.o hook.o
+OBJ=main.o ddhcp.o netsock.o packet.o dhcp.o dhcp_packet.o dhcp_options.o tools.o block.o control.o hook.o logger.o
+OBJCTL=ddhcpctl.o netsock.o packet.o dhcp.o dhcp_packet.o dhcp_options.o tools.o block.o hook.o logger.o
 HDRS=$(wildcard *.h)
 
 REVISION=$(shell git rev-list --first-parent HEAD --max-count=1)

--- a/block.c
+++ b/block.c
@@ -194,14 +194,14 @@ int block_num_free_leases(ddhcp_config* config) {
   DEBUG("block_num_free_leases(blocks, config)\n");
   ddhcp_block* block = config->blocks;
   int free_leases = 0;
-#if LOG_LEVEL >= LOG_DEBUG
+#if LOG_LEVEL_LIMIT >= LOG_DEBUG
   int num_blocks = 0;
 #endif
 
   for (uint32_t i = 0; i < config->number_of_blocks; i++) {
     if (block->state == DDHCP_OURS) {
       free_leases += dhcp_num_free(block);
-#if LOG_LEVEL >= LOG_DEBUG
+#if LOG_LEVEL_LIMIT >= LOG_DEBUG
       num_blocks++;
 #endif
     }
@@ -233,7 +233,7 @@ ddhcp_block* block_find_free_leases(ddhcp_config* config) {
     block++;
   }
 
-#if LOG_LEVEL >= LOG_DEBUG
+#if LOG_LEVEL_LIMIT >= LOG_DEBUG
 
   if (selected != NULL) {
     DEBUG("block_find_free_leases(blocks,config) -> Block %i selected\n", selected->index);

--- a/control.c
+++ b/control.c
@@ -3,6 +3,8 @@
 #include "block.h"
 #include "dhcp_options.h"
 
+extern int log_level;
+
 int handle_command(int socket, uint8_t* buffer, int msglen, ddhcp_config* config) {
   // TODO Rethink command handling and command design
   DEBUG("handle_command(socket, %u, %i, blocks, config)\n", buffer[0], msglen);
@@ -66,6 +68,17 @@ int handle_command(int socket, uint8_t* buffer, int msglen, ddhcp_config* config
 
     uint8_t code = buffer[1];
     remove_option_in_store(&config->options, code);
+    return 0;
+
+  case DDHCPCTL_LOG_LEVEL_SET:
+    DEBUG("handle_command(...) -> set log level\n");
+
+    if (msglen < 2) {
+      DEBUG("handle_command(...) -> message not long enought\n");
+      return -2;
+    }
+
+    log_level = buffer[1];
     return 0;
 
   default:

--- a/control.h
+++ b/control.h
@@ -3,10 +3,13 @@
 
 #include "types.h"
 
-#define DDHCPCTL_BLOCK_SHOW 1
-#define DDHCPCTL_DHCP_OPTIONS_SHOW 2
-#define DDHCPCTL_DHCP_OPTION_SET 3
-#define DDHCPCTL_DHCP_OPTION_REMOVE 4
+enum {
+  DDHCPCTL_BLOCK_SHOW = 1,
+  DDHCPCTL_DHCP_OPTIONS_SHOW,
+  DDHCPCTL_DHCP_OPTION_SET,
+  DDHCPCTL_DHCP_OPTION_REMOVE,
+  DDHCPCTL_LOG_LEVEL_SET,
+};
 
 int handle_command(int socket, uint8_t* buffer, int msglen, ddhcp_config* config);
 

--- a/ddhcp.c
+++ b/ddhcp.c
@@ -106,7 +106,7 @@ void ddhcp_block_process_claims(struct ddhcp_mcast_packet* packet, ddhcp_config*
       // We need to contact him, for dhcp forwarding actions.
       memcpy(&blocks[block_index].owner_address, &packet->sender->sin6_addr, sizeof(struct in6_addr));
       memcpy(&blocks[block_index].node_id, &packet->node_id, sizeof(ddhcp_node_id));
-#if LOG_LEVEL >= LOG_DEBUG
+#if LOG_LEVEL_LIMIT >= LOG_DEBUG
       char ipv6_sender[INET6_ADDRSTRLEN];
       DEBUG("Register block to %s\n",
             inet_ntop(AF_INET6, &blocks[block_index].owner_address, ipv6_sender, INET6_ADDRSTRLEN));
@@ -188,7 +188,7 @@ void ddhcp_dhcp_process(uint8_t* buffer, int len, struct sockaddr_in6 sender, dd
 void ddhcp_dhcp_renewlease(struct ddhcp_mcast_packet* packet, ddhcp_config* config) {
   DEBUG("ddhcp_dhcp_renewlease(request, config)\n");
 
-#if LOG_LEVEL >= LOG_DEBUG
+#if LOG_LEVEL_LIMIT >= LOG_DEBUG
   char* hwaddr = hwaddr2c(packet->renew_payload->chaddr);
   DEBUG("ddhcp_dhcp_renewlease( ... ): Request for xid: %u chaddr: %s\n", packet->renew_payload->xid, hwaddr);
   free(hwaddr);
@@ -221,7 +221,7 @@ void ddhcp_dhcp_renewlease(struct ddhcp_mcast_packet* packet, ddhcp_config* conf
 void ddhcp_dhcp_leaseack(struct ddhcp_mcast_packet* request, ddhcp_config* config) {
   // Stub functions
   DEBUG("ddhcp_dhcp_leaseack(request,config)\n");
-#if LOG_LEVEL >= LOG_DEBUG
+#if LOG_LEVEL_LIMIT >= LOG_DEBUG
   char* hwaddr = hwaddr2c(request->renew_payload->chaddr);
   DEBUG("ddhcp_dhcp_leaseack( ... ): ACK for xid: %u chaddr: %s\n", request->renew_payload->xid, hwaddr);
   free(hwaddr);
@@ -244,7 +244,7 @@ void ddhcp_dhcp_leaseack(struct ddhcp_mcast_packet* request, ddhcp_config* confi
 void ddhcp_dhcp_leasenak(struct ddhcp_mcast_packet* request, ddhcp_config* config) {
   // Stub functions
   DEBUG("ddhcp_dhcp_leasenak(request,config)\n");
-#if LOG_LEVEL >= LOG_DEBUG
+#if LOG_LEVEL_LIMIT >= LOG_DEBUG
   char* hwaddr = hwaddr2c(request->renew_payload->chaddr);
   DEBUG("ddhcp_dhcp_leaseack( ... ): NAK for xid: %u chaddr: %s\n", request->renew_payload->xid, hwaddr);
   free(hwaddr);

--- a/ddhcpctl.c
+++ b/ddhcpctl.c
@@ -27,7 +27,7 @@ int main(int argc, char** argv) {
 #define BUFSIZE_MAX 1500
   uint8_t* buffer = (uint8_t*) calloc(sizeof(uint8_t), BUFSIZE_MAX);
 
-  while ((c = getopt(argc, argv, "C:t:l:bdho:r:")) != -1) {
+  while ((c = getopt(argc, argv, "C:t:l:bdho:r:V:")) != -1) {
     switch (c) {
     case 'h':
       show_usage = 1;
@@ -68,6 +68,12 @@ int main(int argc, char** argv) {
       path = optarg;
       break;
 
+    case 'V':
+      msglen = 2;
+      buffer[0] = (char) DDHCPCTL_LOG_LEVEL_SET;
+      buffer[1] = (char) atoi(optarg);
+      break;
+
     default:
       printf("ARGC: %i\n", argc);
       show_usage = 1;
@@ -94,6 +100,7 @@ int main(int argc, char** argv) {
     printf("-d                     Show the current dhcp options store.\n");
     printf("-l                     Set the dhcp lease time.\n");
     printf("-o CODE:LEN:P1. .. .Pn Set DHCP Option with code,len and #len chars in decimal\n");
+    printf("-V LEVEL               Set log level\n");
     printf("-r CODE                Remove DHCP Option");
     printf("-C PATH                Path to control socket\n");
     exit(0);

--- a/dhcp.c
+++ b/dhcp.c
@@ -12,7 +12,7 @@
 uint16_t DHCP_OFFER_TIMEOUT = 12;
 uint16_t DHCP_LEASE_SERVER_DELTA = 10;
 
-#if LOG_LEVEL >= LOG_DEBUG
+#if LOG_LEVEL_LIMIT >= LOG_DEBUG
 #define DEBUG_DHCP_LEASE(...) do { \
   DEBUG("DHCP LEASE [ state %i, xid %u, end %i ]\n",lease->state,lease->xid,lease->lease_end);\
 } while (0);
@@ -28,7 +28,7 @@ uint16_t DHCP_LEASE_SERVER_DELTA = 10;
  * And 2 on failure.
  */
 uint8_t find_lease_from_address(struct in_addr* addr, ddhcp_config* config, ddhcp_block** lease_block, uint32_t* lease_index) {
-#if LOG_LEVEL >= LOG_DEBUG
+#if LOG_LEVEL_LIMIT >= LOG_DEBUG
   DEBUG("find_lease_from_address( %s, ...)\n", inet_ntoa(*addr));
 #endif
   ddhcp_block* blocks = config->blocks;
@@ -319,7 +319,7 @@ int dhcp_hdl_request(int socket, struct dhcp_packet* request, ddhcp_config* conf
         memcpy(&payload.address, &requested_address, sizeof(struct in_addr));
         payload.xid = request->xid;
         payload.lease_seconds = 0;
-#if LOG_LEVEL >= LOG_DEBUG
+#if LOG_LEVEL_LIMIT >= LOG_DEBUG
         char* hwaddr = hwaddr2c(payload.chaddr);
         DEBUG("dhcp_hdl_request( ... ): Save request for xid: %u chaddr: %s\n", payload.xid, hwaddr);
         free(hwaddr);

--- a/dhcp_packet.c
+++ b/dhcp_packet.c
@@ -12,7 +12,7 @@ struct sockaddr_in broadcast = {
 };
 
 
-#if LOG_LEVEL >= LOG_DEBUG
+#if LOG_LEVEL_LIMIT >= LOG_DEBUG
 void printf_dhcp(dhcp_packet* packet) {
   char* ciaddr_str = (char*) malloc(INET_ADDRSTRLEN);
   inet_ntop(AF_INET, &(packet->ciaddr.s_addr), ciaddr_str, INET_ADDRSTRLEN);
@@ -230,7 +230,7 @@ int ntoh_dhcp_packet(dhcp_packet* packet, uint8_t* buffer, int len) {
 
   assert(i == options);
 
-#if LOG_LEVEL >= LOG_INFO
+#if LOG_LEVEL_LIMIT >= LOG_INFO
   printf_dhcp(packet);
 #endif
 

--- a/logger.c
+++ b/logger.c
@@ -1,0 +1,18 @@
+#include <stdarg.h>
+
+#include "logger.h"
+
+int log_level = LOG_LEVEL_DEFAULT;
+
+void logger(int level, char *prefix, ...) {
+  if (log_level >= level) {
+    va_list args;
+    char *fmt;
+
+    fprintf(stderr, "%s", prefix);
+    va_start(args, prefix);
+    fmt = va_arg(args, typeof(fmt));
+    vfprintf(stderr, fmt, args);
+    va_end(args);
+  }
+}

--- a/logger.h
+++ b/logger.h
@@ -7,61 +7,54 @@
 
 #include <stdio.h>
 
-#define LOG_FATAL   0
-#define LOG_ERROR   5
-#define LOG_WARNING 10
-#define LOG_INFO    15
-#define LOG_DEBUG   20
+#define LOG_FATAL 0
+#define LOG_ERROR 1
+#define LOG_WARNING 2
+#define LOG_INFO 3
+#define LOG_DEBUG 4
 
-#ifndef LOG_LEVEL
-#define LOG_LEVEL LOG_WARNING
+#define LOG_LEVEL_MAX LOG_DEBUG
+
+#ifndef LOG_LEVEL_LIMIT
+#define LOG_LEVEL_LIMIT 255
+#endif
+
+#ifndef LOG_LEVEL_DEFAULT
+#define LOG_LEVEL_DEFAULT LOG_WARNING
 #endif
 
 #define HEX_NODE_ID(x) ((uint8_t*) x)[0],((uint8_t*) x)[1],((uint8_t*) x)[2],((uint8_t*) x)[3],((uint8_t*) x)[4],((uint8_t*) x)[5],((uint8_t*) x)[6],((uint8_t*) x)[7]
 
-#define LOG(...) fprintf(stderr,__VA_ARGS__)
+void logger(int level, char* prefix, ...);
 
-#if LOG_LEVEL >= LOG_FATAL
-#define FATAL(...) do { \
-    fprintf(stderr,"FATAL: "); \
-    fprintf(stderr,__VA_ARGS__); \
-  } while(0)
+#define LOG(...) logger(-1, "",__VA_ARGS__)
+
+#if LOG_LEVEL_LIMIT >= LOG_FATAL
+#define FATAL(...) logger(LOG_FATAL, "FATAL: ", __VA_ARGS__)
 #else
 #define FATAL(...)
 #endif
 
-#if LOG_LEVEL >= LOG_ERROR
-#define ERROR(...) do { \
-    fprintf(stderr,"ERROR: "); \
-    fprintf(stderr,__VA_ARGS__); \
-  } while(0)
+#if LOG_LEVEL_LIMIT >= LOG_ERROR
+#define ERROR(...) logger(LOG_ERROR, "ERROR: ", __VA_ARGS__)
 #else
 #define ERROR(...)
 #endif
 
-#if LOG_LEVEL >= LOG_WARNING
-#define WARNING(...) do { \
-    fprintf(stderr,"WARNING: "); \
-    fprintf(stderr,__VA_ARGS__); \
-  } while(0)
+#if LOG_LEVEL_LIMIT >= LOG_WARNING
+#define WARNING(...) logger(LOG_WARNING, "WARNING: ", __VA_ARGS__)
 #else
 #define WARNING(...)
 #endif
 
-#if LOG_LEVEL >= LOG_INFO
-#define INFO(...) do { \
-    fprintf(stderr,"INFO: "); \
-    fprintf(stderr,__VA_ARGS__); \
-  } while(0)
+#if LOG_LEVEL_LIMIT >= LOG_INFO
+#define INFO(...) logger(LOG_INFO, "INFO: ", __VA_ARGS__)
 #else
 #define INFO(...)
 #endif
 
-#if LOG_LEVEL >= LOG_DEBUG
-#define DEBUG(...) do { \
-    fprintf(stderr,"DEBUG: "); \
-    fprintf(stderr,__VA_ARGS__); \
-  } while(0)
+#if LOG_LEVEL_LIMIT >= LOG_DEBUG
+#define DEBUG(...) logger(LOG_DEBUG, "DEBUG: ", __VA_ARGS__)
 #else
 #define DEBUG(...)
 #endif

--- a/main.c
+++ b/main.c
@@ -27,6 +27,8 @@
 
 volatile int daemon_running = 0;
 
+extern int log_level;
+
 const int NET = 0;
 const int NET_LEN = 10;
 
@@ -158,7 +160,7 @@ int main(int argc, char** argv) {
   int show_usage = 0;
   int early_housekeeping = 0;
 
-  while ((c = getopt(argc, argv, "C:c:i:St:dvDhLb:N:o:s:H:")) != -1) {
+  while ((c = getopt(argc, argv, "C:c:i:St:dvVDhLb:N:o:s:H:")) != -1) {
     switch (c) {
     case 'i':
       interface = optarg;
@@ -251,6 +253,12 @@ int main(int argc, char** argv) {
       config->hook_command = optarg;
       break;
 
+    case 'V':
+      if (log_level < LOG_LEVEL_MAX) {
+        log_level++;
+      }
+      break;
+
     default:
       printf("ARGC: %i\n", argc);
       show_usage = 1;
@@ -276,7 +284,12 @@ int main(int argc, char** argv) {
     printf("-C CTRL_PATH           Path to control socket\n");
     printf("-H COMMAND             Hook to call on events\n");
     printf("-v                     Print build revision\n");
+    printf("-V                     Increase verbosity, can be specified multiple times\n");
     exit(0);
+  }
+
+  if (log_level > LOG_LEVEL_LIMIT) {
+    LOG("WARNING: Requested verbosity is higher than maximum supported by this build\n");
   }
 
   config->number_of_blocks = pow(2, (32 - config->prefix_len - ceil(log2(config->block_size))));
@@ -370,7 +383,7 @@ int main(int argc, char** argv) {
       perror("epoll error:");
     }
 
-#if LOG_LEVEL >= LOG_DEBUG
+#if LOG_LEVEL_LIMIT >= LOG_DEBUG
 
     if (loop_timeout != config->loop_timeout) {
       DEBUG("Increase loop timeout from %i to %i\n", loop_timeout, config->loop_timeout);
@@ -390,7 +403,7 @@ int main(int argc, char** argv) {
         int len;
 
         while ((len = recvfrom(events[i].data.fd, buffer, 1500, 0, (struct sockaddr*) &sender, &sender_len)) > 0) {
-#if LOG_LEVEL >= LOG_DEBUG
+#if LOG_LEVEL_LIMIT >= LOG_DEBUG
           char ipv6_sender[INET6_ADDRSTRLEN];
           DEBUG("Receive message from %s\n",
                 inet_ntop(AF_INET6, get_in_addr((struct sockaddr*)&sender), ipv6_sender, INET6_ADDRSTRLEN));
@@ -402,7 +415,7 @@ int main(int argc, char** argv) {
         int len;
 
         while ((len = recvfrom(events[i].data.fd, buffer, 1500, 0, (struct sockaddr*) &sender, &sender_len)) > 0) {
-#if LOG_LEVEL >= LOG_DEBUG
+#if LOG_LEVEL_LIMIT >= LOG_DEBUG
           char ipv6_sender[INET6_ADDRSTRLEN];
           DEBUG("Receive message from %s\n",
                 inet_ntop(AF_INET6, get_in_addr((struct sockaddr*)&sender), ipv6_sender, INET6_ADDRSTRLEN));

--- a/packet.c
+++ b/packet.c
@@ -300,7 +300,7 @@ int send_packet_direct(struct ddhcp_mcast_packet* packet, struct in6_addr* dest,
 
   memcpy(&dest_addr.sin6_addr, dest, sizeof(struct in6_addr));
 
-#if LOG_LEVEL >= LOG_DEBUG
+#if LOG_LEVEL_LIMIT >= LOG_DEBUG
   char ipv6_sender[INET6_ADDRSTRLEN];
 
   DEBUG("Send message to %s\n",


### PR DESCRIPTION
depends on #20 (first commit is from #20)

This commit adds dynamic verbosity selection to ddhcpd.
It introduces a new command line option `-V` which increases the log
level. The compile time option `LOG_LEVEL` has been removed and replaced
by two new options:
 - LOG_LEVEL_LIMIT
   Sets the maximum debug level available at runtime. Can be used to
   reduce memory footprint slightly, cuts out all unused logging code by
   replacing corresponding log macros by empty macros

 - LOG_LEVEL_DEFAULT
   Sets the default log level

The current log level can be queried and set through the global variable `log_level`.

Additionally this adds the option `-V`to ddhcpdctl, too. It can be used to set the log level of ddhcpd on the fly.

Though this might be a good idea especially since we might want to debug ddhcpd on devices while they are in normal use without getting continous log spam.