### PR TITLE
Remove uncoditional perror

### DIFF
--- a/main.c
+++ b/main.c
@@ -80,7 +80,6 @@ void del_fd(int efd, int fd, uint32_t events) {
   event.events = events;
 
   int s = epoll_ctl(efd, EPOLL_CTL_DEL, fd, &event);
-  perror("epoll_ctl");
 
   if (s < 0) {
     int errsv = errno;


### PR DESCRIPTION
`perror` is invoked unconditionally after call to `epoll_ctl` although it's followed by a conditional call to `perror` that handles all possible error cases.