### PR TITLE
Unlink ddhcpd control socket before binding it

### DIFF
--- a/netsock.c
+++ b/netsock.c
@@ -84,6 +84,8 @@ int control_open(ddhcp_config* state) {
 
   strncpy(s_un.sun_path, state->control_path, sizeof(s_un.sun_path));
 
+  unlink(state->control_path);
+
   if (bind(ctl_sock, (struct sockaddr*)&s_un, sizeof(s_un)) < 0) {
     perror("can't bind control socket");
     goto err;


### PR DESCRIPTION
There might be a left over control socket in case ddhcpd was not shut down properly. By unlinking the path of the socket we can ensure that creation of the socket won't fail.