### PR TITLE
Eliminate superfluous custom list types 

### DIFF
--- a/block.h
+++ b/block.h
@@ -63,7 +63,8 @@ void block_check_timeouts(ddhcp_config* config);
 /**
  * Free block claim list structure.
  */
-void block_free_claims(ddhcp_config* config);
+#define block_free_claims(config) \
+  INIT_LIST_HEAD(&(config)->claiming_blocks);
 
 /**
  * Show Block Status

--- a/dhcp_options.h
+++ b/dhcp_options.h
@@ -57,7 +57,7 @@ dhcp_option* find_in_option_store(dhcp_option_list* options, uint8_t code);
 uint32_t find_in_option_store_address_lease_time(dhcp_option_list* options);
 
 /**
- * Is a option defined in a dhcp_option_list
+ * Is a option defined in a option store
  */
 #define has_in_option_store(options, code) (find_in_option_store(options, code) != NULL)
 
@@ -77,7 +77,7 @@ void remove_option_in_store(dhcp_option_list* store, uint8_t code);
 void free_option_store(dhcp_option_list* store);
 
 /**
- * Print the inventory of a dhcp_option_list into given file descriptor.
+ * Print the inventory of a option store into given file descriptor.
  */
 void dhcp_options_show(int fd, ddhcp_config* config);
 

--- a/dhcp_packet.h
+++ b/dhcp_packet.h
@@ -6,6 +6,9 @@
 #include <netinet/in.h>
 #include "types.h"
 
+// List of dhcp_packet
+typedef struct list_head dhcp_packet_list;
+
 struct dhcp_packet {
   uint8_t op;
   uint8_t htype;
@@ -24,14 +27,10 @@ struct dhcp_packet {
   struct in_addr siaddr;
   struct in_addr giaddr;
   struct dhcp_option* options;
+
+  dhcp_packet_list packet_list;
 };
 typedef struct dhcp_packet dhcp_packet;
-
-struct dhcp_packet_list {
-  struct dhcp_packet* packet;
-  struct list_head list;
-};
-typedef struct dhcp_packet_list dhcp_packet_list;
 
 enum dhcp_message_type {
   DHCPDISCOVER  = 1,

--- a/main.c
+++ b/main.c
@@ -144,7 +144,7 @@ int main(int argc, char** argv) {
 
   // DHCP
   config->dhcp_port = 67;
-  INIT_LIST_HEAD(&(config->options).list);
+  INIT_LIST_HEAD(&config->options);
 
   INIT_LIST_HEAD(&config->claiming_blocks);
 

--- a/main.c
+++ b/main.c
@@ -146,7 +146,7 @@ int main(int argc, char** argv) {
   config->dhcp_port = 67;
   INIT_LIST_HEAD(&(config->options).list);
 
-  INIT_LIST_HEAD(&(config->claiming_blocks).list);
+  INIT_LIST_HEAD(&config->claiming_blocks);
 
   INIT_LIST_HEAD(&(config->dhcp_packet_cache).list);
 

--- a/main.c
+++ b/main.c
@@ -148,7 +148,7 @@ int main(int argc, char** argv) {
 
   INIT_LIST_HEAD(&config->claiming_blocks);
 
-  INIT_LIST_HEAD(&(config->dhcp_packet_cache).list);
+  INIT_LIST_HEAD(&config->dhcp_packet_cache);
 
   char* interface = "server0";
   char* interface_client = "client0";

--- a/types.h
+++ b/types.h
@@ -62,18 +62,17 @@ struct dhcp_lease {
 };
 typedef struct dhcp_lease dhcp_lease;
 
+// List of dhcp_option
+typedef struct list_head dhcp_option_list;
+
 struct dhcp_option {
   uint8_t code;
   uint8_t len;
   uint8_t* payload;
+
+  dhcp_option_list option_list;
 };
 typedef struct dhcp_option dhcp_option;
-
-struct dhcp_option_list {
-  struct dhcp_option* option;
-  struct list_head list;
-};
-typedef struct dhcp_option_list dhcp_option_list;
 
 enum dhcp_option_code {
   // RFC 2132

--- a/types.h
+++ b/types.h
@@ -26,6 +26,9 @@ enum ddhcp_block_state {
   DDHCP_BLOCKED
 };
 
+// List of ddhcp_block
+typedef struct list_head ddhcp_block_list;
+
 struct ddhcp_block {
   uint32_t index;
   enum ddhcp_block_state state;
@@ -37,14 +40,11 @@ struct ddhcp_block {
   time_t timeout;
   // Only iff state is equal to CLAIMED lease_block is not equal to NULL.
   struct dhcp_lease* addresses;
+
+  ddhcp_block_list tmp_list;
+  ddhcp_block_list claim_list;
 };
 typedef struct ddhcp_block ddhcp_block;
-
-struct ddhcp_block_list {
-  struct ddhcp_block* block;
-  struct list_head list;
-};
-typedef struct ddhcp_block_list ddhcp_block_list;
 
 // DHCP structures
 

--- a/types.h
+++ b/types.h
@@ -113,7 +113,7 @@ struct ddhcp_config {
   ddhcp_block_list claiming_blocks;
 
   // DHCP packets for later use.
-  struct dhcp_packet_list dhcp_packet_cache;
+  dhcp_packet_list dhcp_packet_cache;
 
   // DHCP Options
   dhcp_option_list options;


### PR DESCRIPTION
All the custom list structs can be replaced by a list_head member in the corresponding list entry types.

DISCLAIMER: This patch is somewhat untested