### PR TITLE
Type safety

### DIFF
--- a/block.c
+++ b/block.c
@@ -271,12 +271,17 @@ void block_update_claims(int32_t blocks_needed, ddhcp_config* config) {
   }
 
   struct ddhcp_mcast_packet* packet = new_ddhcp_packet(DDHCP_MSG_UPDATECLAIM, config);
+  if (packet == NULL) {
+    WARNING("block_update_claims(...)-> Failed to allocate ddhcpd mcast packet.\n");
+    return;
+  }
   
   // TODO We need to split packets if our_blocks > max_uint8_t
   packet->count = (uint8_t)our_blocks;
   packet->payload = (struct ddhcp_payload*) calloc(sizeof(struct ddhcp_payload), our_blocks);
-  if (packet == NULL) {
-    WARNING("block_update_claims(...)-> Failed to allocate ddhcpd mcast packet.\n");
+  if(!packet->payload) {
+    WARNING("block_update_claims(...)-> Failed to allocate ddhcpd packet payload.\n");
+    free(packet);
     return;
   }
 

--- a/control.c
+++ b/control.c
@@ -48,10 +48,20 @@ int handle_command(int socket, uint8_t* buffer, ssize_t msglen, ddhcp_config* co
     }
 
     dhcp_option* option = (dhcp_option*) calloc(sizeof(dhcp_option), 1);
+    if (option == NULL) {
+      WARNING("handle_command(...) -> Failed to allocate memory for dhcp option\n");
+      return -1;
+    }
+
     option->code = buffer[1];
     option->len = buffer[2];
     printf("%i:%i\n", buffer[1], buffer[2]);
     option->payload = (uint8_t*) calloc(sizeof(uint8_t), option->len);
+    if (option->payload == NULL) {
+      WARNING("handle_command(...) -> Failed to allocate memory for dhcp option payload\n");
+      free(option);
+      return -1;
+    }
 
     memcpy(option->payload, buffer + 3, option->len);
 

--- a/control.c
+++ b/control.c
@@ -42,7 +42,7 @@ int handle_command(int socket, uint8_t* buffer, ssize_t msglen, ddhcp_config* co
       return -2;
     }
 
-    if (buffer[2] > msglen - 3) {
+    if (buffer[2] + 3ul > msglen) {
       DEBUG("handle_command(...) -> message not long enought\n");
       return -2;
     }

--- a/ddhcp.c
+++ b/ddhcp.c
@@ -211,6 +211,11 @@ void ddhcp_dhcp_renewlease(struct ddhcp_mcast_packet* packet, ddhcp_config* conf
     return;
   }
 
+  if (answer == NULL) {
+    WARNING("ddhcp_dhcp_renewlease( ... ) -> Failed to allocate memory for ddhcpd mcast packet.\n");
+    return;
+  }
+
   answer->renew_payload = packet->renew_payload;
 
   send_packet_direct(answer, &packet->sender->sin6_addr, config->server_socket, config->mcast_scope_id);

--- a/ddhcpctl.c
+++ b/ddhcpctl.c
@@ -26,6 +26,10 @@ int main(int argc, char** argv) {
 
 #define BUFSIZE_MAX 1500
   uint8_t* buffer = (uint8_t*) calloc(sizeof(uint8_t), BUFSIZE_MAX);
+  if(!buffer) {
+    fprintf(stderr, "Failed to allocate message buffer\n");
+    exit(1);
+  }
 
   while ((c = getopt(argc, argv, "C:t:l:bdho:r:V:")) != -1) {
     switch (c) {

--- a/ddhcpctl.c
+++ b/ddhcpctl.c
@@ -144,7 +144,7 @@ int main(int argc, char** argv) {
 
   ssize_t br;
 
-  while ((br = recv(ctl_sock, (char*) buffer, sizeof(buffer), 0))) {
+  while ((br = recv(ctl_sock, (char*) buffer, BUFSIZE_MAX, 0))) {
     buffer[br] = '\0';
     printf("%s", (char*) buffer);
   }

--- a/dhcp.c
+++ b/dhcp.c
@@ -446,7 +446,11 @@ int dhcp_nack(int socket, dhcp_packet* from_client) {
 
   packet->options_len = 1;
   packet->options = (dhcp_option*) calloc(sizeof(dhcp_option), 1);
-  // TODO Error handling
+  if (packet->options == NULL) {
+    DEBUG("dhcp_discover(...) -> memory allocation failure\n");
+    free(packet);
+    return 1;
+  }
 
   set_option(packet->options, packet->options_len, DHCP_CODE_MESSAGE_TYPE, 1, (uint8_t[]) {
     DHCPNAK

--- a/dhcp.c
+++ b/dhcp.c
@@ -1,3 +1,4 @@
+#include <errno.h>
 #include <string.h>
 
 #include "block.h"
@@ -327,6 +328,11 @@ int dhcp_hdl_request(int socket, struct dhcp_packet* request, ddhcp_config* conf
 
         // Send packet
         ddhcp_mcast_packet* packet = new_ddhcp_packet(DDHCP_MSG_RENEWLEASE, config);
+        if (packet == NULL) {
+          WARNING("dhcp_hdl_request( ... ): Warning: Failed to allocate memory for ddhcpd mcast packet\n");
+          return -ENOMEM;
+        }
+
         packet->renew_payload = &payload;
 
         // Store packet for later usage.

--- a/dhcp_options.c
+++ b/dhcp_options.c
@@ -208,7 +208,7 @@ void dhcp_options_show(int fd, ddhcp_config* config) {
 
 int dhcp_options_init(ddhcp_config* config) {
   dhcp_option* option;
-  uint8_t pl = config->prefix_len;
+  int8_t pl = (int8_t)config->prefix_len;
 
   if (! has_in_option_store(&config->options, DHCP_CODE_SUBNET_MASK)) {
     // subnet mask
@@ -223,10 +223,10 @@ int dhcp_options_init(ddhcp_config* config) {
       free(option);
       return -ENOMEM;
     }
-    option->payload[0] = (uint8_t)(256 - (256 >> min(max(pl -  0, 0), 8)));
-    option->payload[1] = (uint8_t)(256 - (256 >> min(max(pl -  8, 0), 8)));
-    option->payload[2] = (uint8_t)(256 - (256 >> min(max(pl - 16, 0), 8)));
-    option->payload[3] = (uint8_t)(256 - (256 >> min(max(pl - 24, 0), 8)));
+    option->payload[0] = (uint8_t)(256 - (256 >> min(max((int8_t)(pl -  0), 0), 8)));
+    option->payload[1] = (uint8_t)(256 - (256 >> min(max((int8_t)(pl -  8), 0), 8)));
+    option->payload[2] = (uint8_t)(256 - (256 >> min(max((int8_t)(pl - 16), 0), 8)));
+    option->payload[3] = (uint8_t)(256 - (256 >> min(max((int8_t)(pl - 24), 0), 8)));
 
     set_option_in_store(&config->options, option);
   }

--- a/dhcp_options.h
+++ b/dhcp_options.h
@@ -44,7 +44,7 @@ uint8_t* find_option_requested_address(dhcp_option* options, uint8_t len);
  *
  * Caller must handle memory deallocation.
  */
-uint8_t fill_options(dhcp_option* options, uint8_t len, dhcp_option_list* option_store, uint8_t additional, dhcp_option** fullfil);
+int16_t fill_options(dhcp_option* options, uint8_t len, dhcp_option_list* option_store, uint8_t additional, dhcp_option** fullfil);
 
 /**
  * Search and Retrun a option in an option store. Return null otherwise.
@@ -84,7 +84,7 @@ void dhcp_options_show(int fd, ddhcp_config* config);
 /**
  * Initialize dhcp_options store in the configuration.
  */
-void dhcp_options_init(ddhcp_config* config);
+int dhcp_options_init(ddhcp_config* config);
 
 /**
  * Search for option in store and if found store it in the options list.

--- a/dhcp_packet.c
+++ b/dhcp_packet.c
@@ -13,19 +13,10 @@ struct sockaddr_in broadcast = {
 
 #if LOG_LEVEL_LIMIT >= LOG_DEBUG
 void printf_dhcp(dhcp_packet* packet) {
-  char* ciaddr_str = (char*) malloc(INET_ADDRSTRLEN);
-  inet_ntop(AF_INET, &(packet->ciaddr.s_addr), ciaddr_str, INET_ADDRSTRLEN);
+  char tmpstr[INET_ADDRSTRLEN];
 
-  char* yiaddr_str = (char*) malloc(INET_ADDRSTRLEN);
-  inet_ntop(AF_INET, &(packet->yiaddr.s_addr), yiaddr_str, INET_ADDRSTRLEN);
-
-  char* giaddr_str = (char*) malloc(INET_ADDRSTRLEN);
-  inet_ntop(AF_INET, &(packet->giaddr.s_addr), giaddr_str, INET_ADDRSTRLEN);
-
-  char* siaddr_str = (char*) malloc(INET_ADDRSTRLEN);
-  inet_ntop(AF_INET, &(packet->siaddr.s_addr), siaddr_str, INET_ADDRSTRLEN);
-
-  DEBUG("BOOTP [ op %i, htype %i, hlen %i, hops %i, xid %lu, secs %i, flags %i, ciaddr %s, yiaddr %s, siaddr %s, giaddr %s, sname: %s, file: %s ]\n"
+  inet_ntop(AF_INET, &(packet->ciaddr.s_addr), tmpstr, INET_ADDRSTRLEN);
+  DEBUG("BOOTP [ op %i, htype %i, hlen %i, hops %i, xid %lu, secs %i, flags %i, ciaddr %s, "
         , packet->op
         , packet->htype
         , packet->hlen
@@ -33,18 +24,21 @@ void printf_dhcp(dhcp_packet* packet) {
         , (unsigned long) packet->xid
         , packet->secs
         , packet->flags
-        , ciaddr_str
-        , yiaddr_str
-        , siaddr_str
-        , giaddr_str
+        , tmpstr
+       );
+
+  inet_ntop(AF_INET, &(packet->yiaddr.s_addr), tmpstr, INET_ADDRSTRLEN);
+  DEBUG("yiaddr %s, ", tmpstr);
+
+  inet_ntop(AF_INET, &(packet->siaddr.s_addr), tmpstr, INET_ADDRSTRLEN);
+  DEBUG("siaddr %s, ", tmpstr);
+
+  inet_ntop(AF_INET, &(packet->giaddr.s_addr), tmpstr, INET_ADDRSTRLEN);
+  DEBUG("giaddr %s, sname: %s, file: %s ]\n"
+        , tmpstr
         , packet->sname
         , packet->file
        );
-
-  free(ciaddr_str);
-  free(yiaddr_str);
-  free(giaddr_str);
-  free(siaddr_str);
 
   dhcp_option* option = packet->options;
 

--- a/main.c
+++ b/main.c
@@ -365,6 +365,10 @@ int main(int argc, char** argv) {
 
   /* Buffer where events are returned */
   events = calloc(maxevents, sizeof(struct epoll_event));
+  if(!events) {
+    FATAL("Failed to allocate event buffer\n");
+    abort();
+  }
 
   int need_house_keeping;
   uint32_t loop_timeout = config.loop_timeout = get_loop_timeout(&config);

--- a/main.c
+++ b/main.c
@@ -325,7 +325,10 @@ int main(int argc, char** argv) {
 
   // init block stucture
   ddhcp_block_init(&config);
-  dhcp_options_init(&config);
+  if(dhcp_options_init(&config)) {
+    FATAL("Failed to allocate memory for option store\n");
+    abort();
+  }
   hook_init();
 
   // init network and event loops

--- a/main.c
+++ b/main.c
@@ -338,6 +338,10 @@ int main(int argc, char** argv) {
   }
 
   uint8_t* buffer = (uint8_t*) malloc(sizeof(uint8_t) * 1500);
+  if(!buffer) {
+    FATAL("Failed to allocate network buffer\n");
+    abort();
+  }
   ssize_t bytes = 0;
 
   int efd;

--- a/packet.c
+++ b/packet.c
@@ -115,6 +115,10 @@ ssize_t ntoh_mcast_packet(uint8_t* buffer, ssize_t len, struct ddhcp_mcast_packe
   case DDHCP_MSG_UPDATECLAIM:
     packet->payload = (struct ddhcp_payload*) calloc(sizeof(struct ddhcp_payload), packet->count);
     payload = packet->payload;
+    if (payload == NULL) {
+      WARNING("Failed to allocate packet payload\n");
+      return -ENOMEM;
+    }
 
     for (int i = 0; i < packet->count; i++) {
       copy_buf_to_var_inc(buffer, uint32_t, tmp32);
@@ -135,6 +139,10 @@ ssize_t ntoh_mcast_packet(uint8_t* buffer, ssize_t len, struct ddhcp_mcast_packe
   case DDHCP_MSG_INQUIRE:
     packet->payload = (struct ddhcp_payload*) calloc(sizeof(struct ddhcp_payload), packet->count);
     payload = packet->payload;
+    if (payload == NULL) {
+      WARNING("Failed to allocate packet payload\n");
+      return -ENOMEM;
+    }
 
     for (int i = 0; i < packet->count; i++) {
       copy_buf_to_var_inc(buffer, uint32_t, tmp32);
@@ -151,6 +159,11 @@ ssize_t ntoh_mcast_packet(uint8_t* buffer, ssize_t len, struct ddhcp_mcast_packe
   case DDHCP_MSG_LEASENAK:
   case DDHCP_MSG_RELEASE:
     packet->renew_payload = (struct ddhcp_renew_payload*) calloc(sizeof(struct ddhcp_renew_payload), 1);
+    if (packet->renew_payload == NULL) {
+      WARNING("Failed to allocate packet payload\n");
+      return -ENOMEM;
+    }
+
     copy_buf_to_var_inc(buffer, uint32_t, tmp32);
     packet->renew_payload->address = ntohl(tmp32);
     copy_buf_to_var_inc(buffer, uint32_t, tmp32);

--- a/packet.c
+++ b/packet.c
@@ -54,7 +54,9 @@ ssize_t _packet_size(uint8_t command, ssize_t payload_count) {
 
 struct ddhcp_mcast_packet* new_ddhcp_packet(uint8_t command, ddhcp_config* config) {
   struct ddhcp_mcast_packet* packet = (struct ddhcp_mcast_packet*) calloc(sizeof(struct ddhcp_mcast_packet), 1);
-  // TODO Check we actually got the memory
+  if (packet == NULL) {
+    return NULL;
+  }
   memcpy(&packet->node_id, config->node_id, 8);
   memcpy(&packet->prefix, &config->prefix, sizeof(struct in_addr));
 

--- a/tools.c
+++ b/tools.c
@@ -43,10 +43,18 @@ dhcp_option* parse_option() {
   uint8_t code = (uint8_t)atoi(optarg);
 
   dhcp_option* option = (dhcp_option*) malloc(sizeof(dhcp_option));
+  if(!option) {
+    ERROR("Failed to allocate memory for dhcp option '%s'\n", optarg);
+    exit(1);
+  }
   option->code = code;
   option->len = len;
   option->payload = (uint8_t*)calloc(len, sizeof(uint8_t));
-
+  if(!option->payload) {
+    ERROR("Failed to allocate memory for dhcp option payload '%s'\n", optarg);
+    free(option);
+    exit(1);
+  }
   for (int i = 0 ; i < len; i++) {
     char* next_payload_s = strchr(payload_s, '.');
 


### PR DESCRIPTION
Some additional over/underflow safety commits, 988eab3 fixes a bug that might occur when using prefix lengths < 24

Depends on #29 