### PR TITLE
Fix mips build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,18 +7,28 @@ REVISION=$(shell git rev-list --first-parent HEAD --max-count=1)
 CC=gcc
 CFLAGS+= \
     -Wall \
+    -Wextra \
     -pedantic \
+    -Werror \
     -flto \
     -fno-strict-aliasing \
     -std=c11 \
     -D_GNU_SOURCE \
     -MD -MP \
+    -masm=intel \
+    -Wduplicated-cond \
+    -Wduplicated-branches \
     -Wlogical-op \
+    -Wrestrict \
+    -Wnull-dereference \
     -Wdouble-promotion \
     -Wshadow \
     -Wformat=2 \
     -Wfloat-equal \
     -Wundef \
+    -Wpointer-arith \
+    -Wcast-align \
+    -Wstrict-overflow=5 \
     -Wwrite-strings \
     -Wswitch-default \
     -Wswitch-enum \

--- a/Makefile
+++ b/Makefile
@@ -15,24 +15,16 @@ CFLAGS+= \
     -std=c11 \
     -D_GNU_SOURCE \
     -MD -MP \
-    -masm=intel \
-    -Wduplicated-cond \
-    -Wduplicated-branches \
     -Wlogical-op \
-    -Wrestrict \
-    -Wnull-dereference \
     -Wdouble-promotion \
     -Wshadow \
     -Wformat=2 \
     -Wfloat-equal \
     -Wundef \
     -Wpointer-arith \
-    -Wcast-align \
-    -Wstrict-overflow=5 \
     -Wwrite-strings \
     -Wswitch-default \
     -Wswitch-enum \
-    -Wconversion \
     -Wunreachable-code \
     -Winit-self
 
@@ -50,15 +42,14 @@ ifeq ($(DEBUG),1)
 CFLAGS+= \
     -Og -g \
     -fsanitize=address,signed-integer-overflow,undefined \
+    -masm=intel \
     -Wduplicated-cond \
     -Wduplicated-branches \
-    -Wrestrict \
     -Wnull-dereference \
-    -Wcast-align \
-    -Wpointer-arith \
     -Wstrict-overflow=5 \
-    -Werror \
-    -Wextra
+    -Wrestrict \
+    -Wconversion \
+    -Wcast-align
 
 LFLAGS+= \
     -Og -g \

--- a/block.c
+++ b/block.c
@@ -274,7 +274,7 @@ void block_update_claims(int32_t blocks_needed, ddhcp_config* config) {
   uint32_t our_blocks = 0;
   ddhcp_block* block = config->blocks;
   time_t now = time(NULL);
-  uint32_t timeout_half = ((uint32_t)config->block_timeout * (uint32_t)config->block_refresh_factor) / (config->block_refresh_factor + 1u);
+  int32_t timeout_half = (int32_t)(config->block_timeout * (int32_t)(config->block_refresh_factor) / (config->block_refresh_factor + 1));
 
   // TODO Use a linked list instead of processing the block list twice.
   for (uint32_t i = 0; i < config->number_of_blocks; i++) {

--- a/ddhcpctl.c
+++ b/ddhcpctl.c
@@ -139,9 +139,9 @@ int main(int argc, char** argv) {
 
   ssize_t bw = send(ctl_sock, buffer, msglen, 0);
 
-  if (bw < msglen) {
-    printf("Wrote %i / %u bytes to control socket\n", (int) bw, msglen);
-    perror("send error");
+  if (bw < (ssize_t)msglen) {
+    printf("Wrote %i / %u bytes to control socket", (int) bw, msglen);
+    perror("send error:");
     return -1;
   }
 

--- a/dhcp_packet.c
+++ b/dhcp_packet.c
@@ -95,7 +95,7 @@ ssize_t ntoh_dhcp_packet(dhcp_packet* packet, uint8_t* buffer, ssize_t len) {
     return -1;
   }
 
-  printf("LEN:%li\n", len);
+  printf("LEN:%zi\n", len);
 
   // TODO Use macros to read from the buffer
 
@@ -297,7 +297,7 @@ ssize_t dhcp_packet_send(int socket, dhcp_packet* packet) {
   buffer[_dhcp_packet_len(packet) - 1] = 255;
   assert(obuf + 1 == buffer + _dhcp_packet_len(packet));
   // Network send
-  printf("Message LEN: %li\n", _dhcp_packet_len(packet));
+  printf("Message LEN: %zu\n", _dhcp_packet_len(packet));
 
   broadcast.sin_port = htons(68);
 


### PR DESCRIPTION
This PR fixes some of the insane CFLAGS changes pushed by me yesterday and a few non-portable uses of datatypes. master builds fine for MIPS platforms with this PR applied.