### PR TITLE
chg: Switch -v and -V

### DIFF
--- a/README
+++ b/README
@@ -25,8 +25,8 @@ stupid stuff, but also allow you maximal adaption.
     -D                     Run in foreground and log to console (default)
     -C CTRL_PATH           Path to control socket
     -H COMMAND             Hook to call on events
-    -v                     Print build revision
-    -V                     Increase verbosity, may be specified multiple times
+    -V                     Print build revision
+    -v                     Increase verbosity, may be specified multiple times
 
 Build
 -----

--- a/ddhcpctl.c
+++ b/ddhcpctl.c
@@ -9,6 +9,7 @@
 
 #include "tools.h"
 #include "control.h"
+#include "version.h"
 
 int main(int argc, char** argv) {
 
@@ -32,7 +33,7 @@ int main(int argc, char** argv) {
     exit(1);
   }
 
-  while ((c = getopt(argc, argv, "C:t:l:bdho:r:V:")) != -1) {
+  while ((c = getopt(argc, argv, "C:t:l:bdho:r:v:V")) != -1) {
     switch (c) {
     case 'h':
       show_usage = 1;
@@ -73,11 +74,15 @@ int main(int argc, char** argv) {
       path = optarg;
       break;
 
-    case 'V':
+    case 'v':
       msglen = 2;
       buffer[0] = (uint8_t) DDHCPCTL_LOG_LEVEL_SET;
       buffer[1] = (uint8_t) atoi(optarg);
       break;
+
+    case 'V':
+      printf("Revision: %s\n", REVISION);
+      return 0;
 
     default:
       printf("ARGC: %i\n", argc);
@@ -98,14 +103,15 @@ int main(int argc, char** argv) {
   }
 
   if (show_usage) {
-    printf("Usage: ddhcpctl [-h|-b|-d|-o <option>|-C PATH]\n");
+    printf("Usage: ddhcpctl [-h|-V|-b|-d|-o <option>|-C PATH|-l TIMEOUT|-v VERBOSITY]\n");
     printf("\n");
     printf("-h                     This usage information.\n");
+    printf("-V                     Print build revision\n");
     printf("-b                     Show current block usage.\n");
     printf("-d                     Show the current dhcp options store.\n");
-    printf("-l                     Set the dhcp lease time.\n");
+    printf("-l TIMEOUT             Set the dhcp lease time.\n");
     printf("-o CODE:LEN:P1. .. .Pn Set DHCP Option with code,len and #len chars in decimal\n");
-    printf("-V LEVEL               Set log level\n");
+    printf("-v LEVEL               Set log level\n");
     printf("-r CODE                Remove DHCP Option");
     printf("-C PATH                Path to control socket\n");
     exit(0);

--- a/main.c
+++ b/main.c
@@ -201,10 +201,9 @@ int main(int argc, char** argv) {
       early_housekeeping = 1;
       break;
 
-    case 'v':
+    case 'V':
       printf("Revision: %s\n", REVISION);
       return 0;
-      break;
 
     case 'N':
       do {
@@ -232,7 +231,6 @@ int main(int argc, char** argv) {
           exit(1);
         }
       } while (0);
-
       break;
 
     case 'S':
@@ -244,7 +242,6 @@ int main(int argc, char** argv) {
         dhcp_option* option = parse_option();
         set_option_in_store(&config.options, option);
       } while (0);
-
       break;
 
     case 's':
@@ -259,11 +256,10 @@ int main(int argc, char** argv) {
       config.hook_command = optarg;
       break;
 
-    case 'V':
+    case 'v':
       if (log_level < LOG_LEVEL_MAX) {
         log_level++;
       }
-
       break;
 
     default:
@@ -274,7 +270,7 @@ int main(int argc, char** argv) {
   }
 
   if (show_usage) {
-    printf("Usage: ddhcp [-h] [-d|-D] [-L] [-c CLT-IFACE|-S] [-i SRV-IFACE] [-t TENTATIVE-TIMEOUT]\n");
+    printf("Usage: ddhcpd [-h] [-d|-D] [-L] [-c CLT-IFACE|-S] [-i SRV-IFACE] [-t TENTATIVE-TIMEOUT]\n");
     printf("\n");
     printf("-h                     This usage information.\n");
     printf("-c CLT-IFACE           Interface on which requests from clients are handled\n");
@@ -290,8 +286,8 @@ int main(int argc, char** argv) {
     printf("-D                     Run in foreground and log to console (default)\n");
     printf("-C CTRL_PATH           Path to control socket\n");
     printf("-H COMMAND             Hook to call on events\n");
-    printf("-v                     Print build revision\n");
-    printf("-V                     Increase verbosity, can be specified multiple times\n");
+    printf("-V                     Print build revision\n");
+    printf("-v                     Increase verbosity, can be specified multiple times\n");
     exit(0);
   }
 


### PR DESCRIPTION
This brings the meaning of -v (Verbosity) and -V (Program Version) more into
line with many other utilities that use -v for verbosity control. This patch
also makes -V display the build version as is also common with many other tools.