### PR TITLE
Spare leases

### DIFF
--- a/block.c
+++ b/block.c
@@ -384,7 +384,7 @@ void block_show_status(int fd, ddhcp_config* config) {
   dprintf(fd, "      tentative timeout\t%u\n", config->tentative_timeout);
   dprintf(fd, "      timeout\t%u\n", config->block_timeout);
   dprintf(fd, "      refresh factor\t%u\n", config->block_refresh_factor);
-  dprintf(fd, "      spare\t%u\n", config->spare_blocks_needed);
+  dprintf(fd, "      spare leases needed\t%u\n", config->spare_leases_needed);
   dprintf(fd, "      network: %s/%i \n", inet_ntoa(config->prefix), config->prefix_len);
 
   char node_id[17];

--- a/network-test
+++ b/network-test
@@ -161,8 +161,8 @@ function test_small(){
   trap "pkill ddhcpd ; rm /tmp/ddhcpd-ctl* 2>&1 > /dev/null; $0 net-stop" EXIT
   # Start two daemons
   echo -n "Startup DDHCPD instances "
-  ( $0 srv-start 0 ./ddhcpd -L -t 20 -C /tmp/ddhcpd-ctl0 -c client0 -i server0 > /tmp/ddhcpd-0.log -H $(pwd)/example-hook.sh 2>&1 ; echo -n "." ) &
-  ( $0 srv-start 1 ./ddhcpd -L -t 20 -C /tmp/ddhcpd-ctl1 -c client0 -i server0 > /tmp/ddhcpd-1.log -H $(pwd)/example-hook.sh 2>&1 ; echo -n "." ) &
+  ( $0 srv-start 0 ./ddhcpd -L -t 20 -b 2 -C /tmp/ddhcpd-ctl0 -c client0 -i server0 > /tmp/ddhcpd-0.log -H $(pwd)/example-hook.sh 2>&1 ; echo -n "." ) &
+  ( $0 srv-start 1 ./ddhcpd -L -t 20 -b 2 -C /tmp/ddhcpd-ctl1 -c client0 -i server0 > /tmp/ddhcpd-1.log -H $(pwd)/example-hook.sh 2>&1 ; echo -n "." ) &
   echo " done"
   # Start some clients 
   echo "Starting clients on realm 0 "
@@ -186,8 +186,8 @@ function test_one(){
   NUMBER_OF_CLIENT_INTERFACES=1
   $0 net-init 1
   echo -n "Startup DDHCPD instances"
-  ( $0 srv-start 0 ./ddhcpd -L -s 1 -t 15 -B 300 -C /tmp/ddhcpd-ctl0 -c client0 -i server0 -N 10.0.128.0/17 -o 54:4:10.0.0.1 -o 1:4:255.255.0.0 -o 51:4:0.0.1.44 > /tmp/ddhcpd-0.log -H $(pwd)/example-hook.sh 2>&1 ; echo -n "." ) &
-  ( $0 srv-start 1 ./ddhcpd -L -s 1 -t 15 -B 300 -C /tmp/ddhcpd-ctl1 -c client0 -i server0 -N 10.0.128.0/17 -o 54:4:10.0.0.1 -o 1:4:255.255.0.0 -o 51:4:0.0.1.44 > /tmp/ddhcpd-1.log -H $(pwd)/example-hook.sh 2>&1 ; echo -n "." ) &
+  ( $0 srv-start 0 ./ddhcpd -L -s 2 -t 15 -B 300 -b 2 -C /tmp/ddhcpd-ctl0 -c client0 -i server0 -N 10.0.128.0/17 -o 54:4:10.0.0.1 -o 1:4:255.255.0.0 -o 51:4:0.0.1.44 > /tmp/ddhcpd-0.log -H $(pwd)/example-hook.sh 2>&1 ; echo -n "." ) &
+  ( $0 srv-start 1 ./ddhcpd -L -s 2 -t 15 -B 300 -b 2 -C /tmp/ddhcpd-ctl1 -c client0 -i server0 -N 10.0.128.0/17 -o 54:4:10.0.0.1 -o 1:4:255.255.0.0 -o 51:4:0.0.1.44 > /tmp/ddhcpd-1.log -H $(pwd)/example-hook.sh 2>&1 ; echo -n "." ) &
   echo " done"
   startDHCPClients 0 -v
   startDHCPClients 1 -v
@@ -204,11 +204,11 @@ function test_full(){
   trap "pkill ddhcpd ; rm /tmp/ddhcpd-ctl* 2>&1 > /dev/null; $0 net-stop" EXIT
   # Start deamons
   echo -n "Startup DDHCPD instances"
-  ( $0 srv-start 0 ./ddhcpd -L -s 1 -t 15 -B 300 -C /tmp/ddhcpd-ctl0 -c client0 -i server0 -N 10.0.128.0/17 -o 54:4:10.0.0.1 -o 1:4:255.255.0.0 -o 51:4:0.0.1.44 > /tmp/ddhcpd-0.log -H $(pwd)/example-hook.sh 2>&1 ; echo -n "." ) &
-  ( $0 srv-start 1 ./ddhcpd -L -s 1 -t 15 -B 300 -C /tmp/ddhcpd-ctl1 -c client0 -i server0 -N 10.0.128.0/17 -o 54:4:10.0.0.1 -o 1:4:255.255.0.0 -o 51:4:0.0.1.44 > /tmp/ddhcpd-1.log -H $(pwd)/example-hook.sh 2>&1 ; echo -n "." ) &
-  ( $0 srv-start 2 ./ddhcpd -L -s 1 -t 15 -B 300 -C /tmp/ddhcpd-ctl1 -c client0 -i server0 -N 10.0.128.0/17 -o 54:4:10.0.0.1 -o 1:4:255.255.0.0 -o 51:4:0.0.1.44 > /tmp/ddhcpd-2.log -H $(pwd)/example-hook.sh 2>&1 ; echo -n "." ) &
-  ( $0 srv-start 3 ./ddhcpd -L -s 1 -t 15 -B 300 -C /tmp/ddhcpd-ctl1 -c client0 -i server0 -N 10.0.128.0/17 -o 54:4:10.0.0.1 -o 1:4:255.255.0.0 -o 51:4:0.0.1.44 > /tmp/ddhcpd-3.log -H $(pwd)/example-hook.sh 2>&1 ; echo -n "." ) &
-  ( $0 srv-start 4 ./ddhcpd -L -s 1 -t 15 -B 300 -C /tmp/ddhcpd-ctl1 -c client0 -i server0 -N 10.0.128.0/17 -o 54:4:10.0.0.1 -o 1:4:255.255.0.0 -o 51:4:0.0.1.44 > /tmp/ddhcpd-4.log -H $(pwd)/example-hook.sh 2>&1 ; echo -n "." ) &
+  ( $0 srv-start 0 ./ddhcpd -L -s 2 -t 15 -B 300 -b 2 -C /tmp/ddhcpd-ctl0 -c client0 -i server0 -N 10.0.128.0/17 -o 54:4:10.0.0.1 -o 1:4:255.255.0.0 -o 51:4:0.0.1.44 > /tmp/ddhcpd-0.log 2>&1;) &
+  ( $0 srv-start 1 ./ddhcpd -L -s 2 -t 15 -B 300 -b 2 -C /tmp/ddhcpd-ctl1 -c client0 -i server0 -N 10.0.128.0/17 -o 54:4:10.0.0.1 -o 1:4:255.255.0.0 -o 51:4:0.0.1.44 > /tmp/ddhcpd-1.log 2>&1;) &
+  ( $0 srv-start 2 ./ddhcpd -L -s 2 -t 15 -B 300 -b 2 -C /tmp/ddhcpd-ctl1 -c client0 -i server0 -N 10.0.128.0/17 -o 54:4:10.0.0.1 -o 1:4:255.255.0.0 -o 51:4:0.0.1.44 > /tmp/ddhcpd-2.log 2>&1;) &
+  ( $0 srv-start 3 ./ddhcpd -L -s 2 -t 15 -B 300 -b 2 -C /tmp/ddhcpd-ctl1 -c client0 -i server0 -N 10.0.128.0/17 -o 54:4:10.0.0.1 -o 1:4:255.255.0.0 -o 51:4:0.0.1.44 > /tmp/ddhcpd-3.log 2>&1;) &
+  ( $0 srv-start 4 ./ddhcpd -L -s 2 -t 15 -B 300 -b 2 -C /tmp/ddhcpd-ctl1 -c client0 -i server0 -N 10.0.128.0/17 -o 54:4:10.0.0.1 -o 1:4:255.255.0.0 -o 51:4:0.0.1.44 > /tmp/ddhcpd-4.log 2>&1;) &
   echo " done"
   startDHCPClients 0 -v
   startDHCPClients 1 -v

--- a/types.h
+++ b/types.h
@@ -137,7 +137,7 @@ struct ddhcp_config {
   uint16_t block_refresh_factor;
   uint16_t tentative_timeout;
   uint8_t block_size;
-  uint8_t spare_blocks_needed;
+  uint8_t spare_leases_needed;
   struct in_addr prefix;
   uint8_t prefix_len;
   uint8_t disable_dhcp;


### PR DESCRIPTION
Instead of spare blocks handle spare leases. This should prevent 
instant block inquires after the first client.

Please review, the statistics code should be merged first.