### PR TITLE
Mark function parameters as nonnull where applicable

### DIFF
--- a/block.c
+++ b/block.c
@@ -39,7 +39,7 @@ int block_alloc(ddhcp_block* block) {
   return 0;
 }
 
-int block_own(ddhcp_block* block, ddhcp_config* config) {
+ATTR_NONNULL(2) int block_own(ddhcp_block* block, ddhcp_config* config) {
   if (!block) {
     WARNING("block_own(...): No block given to own\n");
     return 1;
@@ -56,7 +56,7 @@ int block_own(ddhcp_block* block, ddhcp_config* config) {
   return 0;
 }
 
-void block_free(ddhcp_block* block) {
+ATTR_NONNULL_ALL void block_free(ddhcp_block* block) {
   DEBUG("block_free(%i)\n", block->index);
 
   if (block->state != DDHCP_BLOCKED) {
@@ -73,7 +73,7 @@ void block_free(ddhcp_block* block) {
   }
 }
 
-ddhcp_block* block_find_free(ddhcp_config* config) {
+ATTR_NONNULL_ALL ddhcp_block* block_find_free(ddhcp_config* config) {
   DEBUG("block_find_free(config)\n");
   ddhcp_block* block = config->blocks;
 
@@ -127,7 +127,7 @@ ddhcp_block* block_find_free(ddhcp_config* config) {
   return random_free;
 }
 
-int block_claim(int32_t num_blocks, ddhcp_config* config) {
+ATTR_NONNULL_ALL int block_claim(int32_t num_blocks, ddhcp_config* config) {
   DEBUG("block_claim(count:%i, config)\n", num_blocks);
 
   // Handle blocks already in claiming prozess
@@ -234,7 +234,7 @@ int block_claim(int32_t num_blocks, ddhcp_config* config) {
   return 0;
 }
 
-uint32_t block_num_free_leases(ddhcp_config* config) {
+ATTR_NONNULL_ALL uint32_t block_num_free_leases(ddhcp_config* config) {
   DEBUG("block_num_free_leases(config)\n");
 
   ddhcp_block* block = config->blocks;
@@ -258,7 +258,7 @@ uint32_t block_num_free_leases(ddhcp_config* config) {
   return free_leases;
 }
 
-ddhcp_block* block_find_free_leases(ddhcp_config* config) {
+ATTR_NONNULL_ALL ddhcp_block* block_find_free_leases(ddhcp_config* config) {
   DEBUG("block_find_free_leases(config)\n");
 
   ddhcp_block* block = config->blocks;
@@ -294,7 +294,7 @@ ddhcp_block* block_find_free_leases(ddhcp_config* config) {
   return selected;
 }
 
-void block_drop_unused(ddhcp_config* config) {
+ATTR_NONNULL_ALL void block_drop_unused(ddhcp_config* config) {
   DEBUG("block_drop_unsued(config)\n");
   ddhcp_block* block = config->blocks;
   ddhcp_block* freeable_block = NULL;
@@ -340,8 +340,9 @@ void block_drop_unused(ddhcp_config* config) {
   }
 }
 
-void _block_update_claim_send(struct ddhcp_mcast_packet* packet, time_t new_block_timeout, ddhcp_config* config) {
+ATTR_NONNULL_ALL static void _block_update_claim_send(struct ddhcp_mcast_packet* packet, time_t new_block_timeout, ddhcp_config* config) {
   DEBUG("block_update_claims_send(packet:%i,%li,config)\n",packet->count,new_block_timeout);
+
   statistics_record(config, STAT_MCAST_SEND_PKG, 1);
   statistics_record(config, STAT_MCAST_SEND_UPDATECLAIM, 1);
   ssize_t bytes_send = send_packet_mcast(packet, config->mcast_socket, config->mcast_scope_id);
@@ -361,7 +362,7 @@ void _block_update_claim_send(struct ddhcp_mcast_packet* packet, time_t new_bloc
   }
 }
 
-void block_update_claims(ddhcp_config* config) {
+ATTR_NONNULL_ALL void block_update_claims(ddhcp_config* config) {
   DEBUG("block_update_claims(config)\n");
   uint32_t our_blocks = 0;
   ddhcp_block* block = config->blocks;
@@ -445,7 +446,7 @@ void block_update_claims(ddhcp_config* config) {
   free(packet);
 }
 
-void block_check_timeouts(ddhcp_config* config) {
+ATTR_NONNULL_ALL void block_check_timeouts(ddhcp_config* config) {
   DEBUG("block_check_timeouts(config)\n");
   ddhcp_block* block = config->blocks;
   time_t now = time(NULL);
@@ -470,7 +471,7 @@ void block_check_timeouts(ddhcp_config* config) {
   }
 }
 
-void block_show_status(int fd, ddhcp_config* config) {
+ATTR_NONNULL_ALL void block_show_status(int fd, ddhcp_config* config) {
   ddhcp_block* block = config->blocks;
   dprintf(fd, "block size/number\t%u/%u \n", config->block_size, config->number_of_blocks);
   dprintf(fd, "      tentative timeout\t%u\n", config->tentative_timeout);

--- a/block.h
+++ b/block.h
@@ -14,36 +14,36 @@ int block_alloc(ddhcp_block* block);
  * Own a block, possibly after you have claimed it an amount of times.
  * This will also malloc and prepare a dhcp_lease_block inside the given block.
  */
-int block_own(ddhcp_block* block, ddhcp_config* config);
+ATTR_NONNULL(2) int block_own(ddhcp_block* block, ddhcp_config* config);
 
 /**
  * Free a block and release dhcp_lease_block when allocated.
  */
-void block_free(ddhcp_block* block);
+ATTR_NONNULL_ALL void block_free(ddhcp_block* block);
 
 /**
  * Find a free block and return it or otherwise NULL.
  * A block is called free, when no other node claims it.
  */
-ddhcp_block* block_find_free(ddhcp_config* config);
+ATTR_NONNULL_ALL ddhcp_block* block_find_free(ddhcp_config* config);
 
 /**
  * Claim a block! A block is only claimable when it is free.
  * Returns a value greater 0 if something goes sideways.
  */
-int block_claim(int32_t num_blocks, ddhcp_config* config);
+ATTR_NONNULL_ALL int block_claim(int32_t num_blocks, ddhcp_config* config);
 
 /**
  * Sum the number of free leases in blocks you own.
  */
-uint32_t block_num_free_leases(ddhcp_config* config);
+ATTR_NONNULL_ALL uint32_t block_num_free_leases(ddhcp_config* config);
 
 /**
  * Find and return claimed block with free leases. Try to
  * reduce fragmentation of lease usage by returning already
  * used blocks.
  */
-ddhcp_block* block_find_free_leases(ddhcp_config* config);
+ATTR_NONNULL_ALL ddhcp_block* block_find_free_leases(ddhcp_config* config);
 
 /**
  * Drop the youngest unused block.
@@ -51,7 +51,7 @@ ddhcp_block* block_find_free_leases(ddhcp_config* config);
  * and stop updating the claim. Freeing the block after its
  * timeout.
  */
-void block_drop_unused(ddhcp_config* config);
+ATTR_NONNULL_ALL void block_drop_unused(ddhcp_config* config);
 
 /**
  *  Update the timeout of claimed blocks and send packets to
@@ -60,13 +60,13 @@ void block_drop_unused(ddhcp_config* config);
  *  Due to fragmented timeouts this packet may send 2 times more packets
  *  than optimal. TODO fixthis
  */
-void block_update_claims(ddhcp_config* config);
+ATTR_NONNULL_ALL void block_update_claims(ddhcp_config* config);
 
 /**
  * Check the timeout of all blocks, and mark timed out once as FREE.
  * Blocks which are marked as BLOCKED are ignored in this process.
  */
-void block_check_timeouts(ddhcp_config* config);
+ATTR_NONNULL_ALL void block_check_timeouts(ddhcp_config* config);
 
 /**
  * Free block claim list structure.
@@ -77,7 +77,7 @@ void block_check_timeouts(ddhcp_config* config);
 /**
  * Show Block Status
  */
-void block_show_status(int fd, ddhcp_config* config);
+ATTR_NONNULL_ALL void block_show_status(int fd, ddhcp_config* config);
 
 /**
  * Reset needless markers in all blocks

--- a/control.c
+++ b/control.c
@@ -6,7 +6,7 @@
 
 extern int log_level;
 
-int handle_command(int socket, uint8_t* buffer, ssize_t msglen, ddhcp_config* config) {
+ATTR_NONNULL_ALL int handle_command(int socket, uint8_t* buffer, ssize_t msglen, ddhcp_config* config) {
   if (msglen == 0) {
     DEBUG("handle_command(...): zero length command received\n");
     return -2;

--- a/control.h
+++ b/control.h
@@ -13,6 +13,6 @@ enum {
   DDHCPCTL_STATISTICS_RESET,
 };
 
-int handle_command(int socket, uint8_t* buffer, ssize_t msglen, ddhcp_config* config);
+ATTR_NONNULL_ALL int handle_command(int socket, uint8_t* buffer, ssize_t msglen, ddhcp_config* config);
 
 #endif

--- a/ddhcp.c
+++ b/ddhcp.c
@@ -6,7 +6,7 @@
 #include "tools.h"
 #include "statistics.h"
 
-int ddhcp_block_init(ddhcp_config* config) {
+ATTR_NONNULL_ALL int ddhcp_block_init(ddhcp_config* config) {
   DEBUG("ddhcp_block_init(config)\n");
 
   if (config->number_of_blocks < 1) {
@@ -42,7 +42,7 @@ int ddhcp_block_init(ddhcp_config* config) {
   return 0;
 }
 
-void ddhcp_block_free(ddhcp_config* config) {
+ATTR_NONNULL_ALL void ddhcp_block_free(ddhcp_config* config) {
   ddhcp_block* block = config->blocks;
 
   for (uint32_t i = 0; i < config->number_of_blocks; i++) {
@@ -53,7 +53,7 @@ void ddhcp_block_free(ddhcp_config* config) {
   free(config->blocks);
 }
 
-int ddhcp_check_packet(struct ddhcp_mcast_packet* packet, ddhcp_config* config) {
+ATTR_NONNULL_ALL int ddhcp_check_packet(struct ddhcp_mcast_packet* packet, ddhcp_config* config) {
   if (memcmp(&packet->prefix, &config->prefix, sizeof(struct in_addr)) != 0 ||
       packet->prefix_len != config->prefix_len ||
       packet->blocksize != config->block_size) {
@@ -63,7 +63,7 @@ int ddhcp_check_packet(struct ddhcp_mcast_packet* packet, ddhcp_config* config) 
   return 0;
 }
 
-void ddhcp_block_process(uint8_t* buffer, ssize_t len, struct sockaddr_in6 sender, ddhcp_config* config) {
+ATTR_NONNULL_ALL void ddhcp_block_process(uint8_t* buffer, ssize_t len, struct sockaddr_in6 sender, ddhcp_config* config) {
   struct ddhcp_mcast_packet packet;
   ssize_t ret = ntoh_mcast_packet(buffer, len, &packet);
   packet.sender = &sender;
@@ -97,7 +97,7 @@ void ddhcp_block_process(uint8_t* buffer, ssize_t len, struct sockaddr_in6 sende
   }
 }
 
-void ddhcp_block_process_claims(struct ddhcp_mcast_packet* packet, ddhcp_config* config) {
+ATTR_NONNULL_ALL void ddhcp_block_process_claims(struct ddhcp_mcast_packet* packet, ddhcp_config* config) {
   DEBUG("ddhcp_block_process_claims(packet,config)\n");
 
   assert(packet->command == 1);
@@ -141,7 +141,7 @@ void ddhcp_block_process_claims(struct ddhcp_mcast_packet* packet, ddhcp_config*
   }
 }
 
-void ddhcp_block_process_inquire(struct ddhcp_mcast_packet* packet, ddhcp_config* config) {
+ATTR_NONNULL_ALL void ddhcp_block_process_inquire(struct ddhcp_mcast_packet* packet, ddhcp_config* config) {
   DEBUG("ddhcp_block_process_inquire(packet,config)\n");
 
   assert(packet->command == 2);
@@ -183,7 +183,7 @@ void ddhcp_block_process_inquire(struct ddhcp_mcast_packet* packet, ddhcp_config
   }
 }
 
-void ddhcp_dhcp_process(uint8_t* buffer, ssize_t len, struct sockaddr_in6 sender, ddhcp_config* config) {
+ATTR_NONNULL_ALL void ddhcp_dhcp_process(uint8_t* buffer, ssize_t len, struct sockaddr_in6 sender, ddhcp_config* config) {
   struct ddhcp_mcast_packet packet;
   ssize_t ret = ntoh_mcast_packet(buffer, len, &packet);
   packet.sender = &sender;
@@ -223,7 +223,7 @@ void ddhcp_dhcp_process(uint8_t* buffer, ssize_t len, struct sockaddr_in6 sender
   }
 }
 
-void ddhcp_dhcp_renewlease(struct ddhcp_mcast_packet* packet, ddhcp_config* config) {
+ATTR_NONNULL_ALL void ddhcp_dhcp_renewlease(struct ddhcp_mcast_packet* packet, ddhcp_config* config) {
   DEBUG("ddhcp_dhcp_renewlease(request,config)\n");
 
 #if LOG_LEVEL_LIMIT >= LOG_DEBUG
@@ -267,7 +267,7 @@ void ddhcp_dhcp_renewlease(struct ddhcp_mcast_packet* packet, ddhcp_config* conf
   free(answer);
 }
 
-void ddhcp_dhcp_leaseack(struct ddhcp_mcast_packet* request, ddhcp_config* config) {
+ATTR_NONNULL_ALL void ddhcp_dhcp_leaseack(struct ddhcp_mcast_packet* request, ddhcp_config* config) {
   // Stub functions
   DEBUG("ddhcp_dhcp_leaseack(request,config)\n");
 
@@ -292,7 +292,7 @@ void ddhcp_dhcp_leaseack(struct ddhcp_mcast_packet* request, ddhcp_config* confi
   free(request->renew_payload);
 }
 
-void ddhcp_dhcp_leasenak(struct ddhcp_mcast_packet* request, ddhcp_config* config) {
+ATTR_NONNULL_ALL void ddhcp_dhcp_leasenak(struct ddhcp_mcast_packet* request, ddhcp_config* config) {
   // Stub functions
   DEBUG("ddhcp_dhcp_leasenak(request,config)\n");
 
@@ -317,7 +317,7 @@ void ddhcp_dhcp_leasenak(struct ddhcp_mcast_packet* request, ddhcp_config* confi
   free(request->renew_payload);
 }
 
-void ddhcp_dhcp_release(struct ddhcp_mcast_packet* packet, ddhcp_config* config) {
+ATTR_NONNULL_ALL void ddhcp_dhcp_release(struct ddhcp_mcast_packet* packet, ddhcp_config* config) {
   DEBUG("ddhcp_dhcp_release(packet,config)\n");
   dhcp_release_lease(packet->renew_payload->address, config);
   free(packet->renew_payload);

--- a/ddhcp.h
+++ b/ddhcp.h
@@ -9,61 +9,61 @@
  * Initialise the blocks data structure in the global configuration state.
  * It should only be called by the main program.
  */
-int ddhcp_block_init(ddhcp_config* config);
+ATTR_NONNULL_ALL int ddhcp_block_init(ddhcp_config* config);
 /**
  * This is the inverse function to ddhcp_block_init.
  */
-void ddhcp_block_free(ddhcp_config* config);
+ATTR_NONNULL_ALL void ddhcp_block_free(ddhcp_config* config);
 
 /**
  * ddhcp_block_process is part of the network message processing chain.
  * Here messages related to the block consensus are processed.
  */
-void ddhcp_block_process(uint8_t* buffer, ssize_t len, struct sockaddr_in6 sender, ddhcp_config* config);
+ATTR_NONNULL_ALL void ddhcp_block_process(uint8_t* buffer, ssize_t len, struct sockaddr_in6 sender, ddhcp_config* config);
 /**
  * A node sends a claim message for each block he thinks he owns, handling these
  * message is handled in ddhcp_block_process_claims.
  */
-void ddhcp_block_process_claims(struct ddhcp_mcast_packet* packet, ddhcp_config* config);
+ATTR_NONNULL_ALL void ddhcp_block_process_claims(struct ddhcp_mcast_packet* packet, ddhcp_config* config);
 /**
  * Before claiming a block, a node inquires that block three times, by sending
  * an inquire message. Handling these messages is done in ddhcp_block_process_inquire.
  */
-void ddhcp_block_process_inquire(struct ddhcp_mcast_packet* packet, ddhcp_config* config);
+ATTR_NONNULL_ALL void ddhcp_block_process_inquire(struct ddhcp_mcast_packet* packet, ddhcp_config* config);
 
 /**
  * ddhcp_dhcp_process is part of the network message processing chain.
  * In this part of the chain dhcp packages which are forwarded between ddhcpd nodes
  * or related messages are processed.
  */
-void ddhcp_dhcp_process(uint8_t* buffer, ssize_t len, struct sockaddr_in6 sender, ddhcp_config* config);
+ATTR_NONNULL_ALL void ddhcp_dhcp_process(uint8_t* buffer, ssize_t len, struct sockaddr_in6 sender, ddhcp_config* config);
 /**
  * When a ddhcpd node gets a dhcp renew request for an address in a block that
  * is owned by another node, it requests a renew from the owning node. The
  * function ddhcp_dhcp_renewlease handles receiving such a request.
  */
-void ddhcp_dhcp_renewlease(struct ddhcp_mcast_packet* packet, ddhcp_config* config);
+ATTR_NONNULL_ALL void ddhcp_dhcp_renewlease(struct ddhcp_mcast_packet* packet, ddhcp_config* config);
 /**
  * After this node has send a renew request to another node. The other node
  * may send an acknowledge package. We handle receiving such a message
  * in ddhcp_dhcp_leaseack.
  */
-void ddhcp_dhcp_leaseack(struct ddhcp_mcast_packet* packet, ddhcp_config* config);
+ATTR_NONNULL_ALL void ddhcp_dhcp_leaseack(struct ddhcp_mcast_packet* packet, ddhcp_config* config);
 /**
  * After this node has send a renew request to another node. The other node
  * may send an no acknowledge package. We handle receiving such a message
  * in ddhcp_dhcp_leasenack.
  */
-void ddhcp_dhcp_leasenak(struct ddhcp_mcast_packet* packet, ddhcp_config* config);
+ATTR_NONNULL_ALL void ddhcp_dhcp_leasenak(struct ddhcp_mcast_packet* packet, ddhcp_config* config);
 /**
  * When a node receives a dhcp release packet for an address in a block owned
  * by another node, it should forward a release request to the owner.
  * The ddhcp_dhcp_release function handles processing of such a package.
  */
-void ddhcp_dhcp_release(struct ddhcp_mcast_packet* packet, ddhcp_config* config);
+ATTR_NONNULL_ALL void ddhcp_dhcp_release(struct ddhcp_mcast_packet* packet, ddhcp_config* config);
 
-ddhcp_block* block_find_lease(ddhcp_config* config);
+ATTR_NONNULL_ALL ddhcp_block* block_find_lease(ddhcp_config* config);
 
-void house_keeping(ddhcp_config* config);
+ATTR_NONNULL_ALL void house_keeping(ddhcp_config* config);
 
 #endif

--- a/dhcp.c
+++ b/dhcp.c
@@ -30,7 +30,7 @@ uint16_t DHCP_LEASE_SERVER_DELTA = 10;
  * Of 1, iff result is non in our blocks.
  * And 2 on failure.
  */
-uint8_t find_lease_from_address(struct in_addr* addr, ddhcp_config* config, ddhcp_block** lease_block, uint32_t* lease_index) {
+ATTR_NONNULL(1,2) uint8_t find_lease_from_address(struct in_addr* addr, ddhcp_config* config, ddhcp_block** lease_block, uint32_t* lease_index) {
 #if LOG_LEVEL_LIMIT >= LOG_DEBUG
   DEBUG("find_lease_from_address(%s, ...)\n", inet_ntoa(*addr));
 #endif
@@ -67,7 +67,7 @@ uint8_t find_lease_from_address(struct in_addr* addr, ddhcp_config* config, ddhc
   return 2;
 }
 
-void _dhcp_release_lease(ddhcp_block* block, uint32_t lease_index) {
+ATTR_NONNULL_ALL static void _dhcp_release_lease(ddhcp_block* block, uint32_t lease_index) {
   INFO("dhcp_release_lease(...): Releasing lease %i in block %i\n", lease_index, block->index);
   dhcp_lease* lease = block->addresses + lease_index;
 
@@ -79,7 +79,7 @@ void _dhcp_release_lease(ddhcp_block* block, uint32_t lease_index) {
   lease->state = FREE;
 }
 
-dhcp_packet* build_initial_packet(dhcp_packet* from_client) {
+ATTR_NONNULL_ALL dhcp_packet* build_initial_packet(dhcp_packet* from_client) {
   DEBUG("build_initial_packet(from_client)\n");
 
   dhcp_packet* packet = (dhcp_packet*) calloc(sizeof(dhcp_packet), 1);
@@ -110,7 +110,7 @@ dhcp_packet* build_initial_packet(dhcp_packet* from_client) {
 
 uint8_t _ddo[1] = { 0 };
 
-int16_t _dhcp_default_options(uint8_t msg_type, dhcp_packet* packet, dhcp_packet* request, ddhcp_config* config, bool include_lease_time) {
+ATTR_NONNULL_ALL static int16_t _dhcp_default_options(uint8_t msg_type, dhcp_packet* packet, dhcp_packet* request, ddhcp_config* config, bool include_lease_time) {
   int16_t num_options;
   // TODO We need a more extendable way to build up options
   // TODO Proper error handling
@@ -139,7 +139,7 @@ int16_t _dhcp_default_options(uint8_t msg_type, dhcp_packet* packet, dhcp_packet
   return 0;
 }
 
-int dhcp_process(uint8_t* buffer, ssize_t len, ddhcp_config* config) {
+ATTR_NONNULL_ALL int dhcp_process(uint8_t* buffer, ssize_t len, ddhcp_config* config) {
   // TODO Error Handling
   struct dhcp_packet dhcp_packet_buf;
   ssize_t ret = ntoh_dhcp_packet(&dhcp_packet_buf, buffer, len);
@@ -189,7 +189,7 @@ int dhcp_process(uint8_t* buffer, ssize_t len, ddhcp_config* config) {
   return 0;
 }
 
-int dhcp_hdl_discover(int socket, dhcp_packet* discover, ddhcp_config* config) {
+ATTR_NONNULL_ALL int dhcp_hdl_discover(int socket, dhcp_packet* discover, ddhcp_config* config) {
   DEBUG("dhcp_hdl_discover(socket:%i, packet, config)\n", socket);
 
   time_t now = time(NULL);
@@ -252,7 +252,7 @@ int dhcp_hdl_discover(int socket, dhcp_packet* discover, ddhcp_config* config) {
   return 0;
 }
 
-int dhcp_rhdl_request(uint32_t* address, ddhcp_config* config) {
+ATTR_NONNULL_ALL int dhcp_rhdl_request(uint32_t* address, ddhcp_config* config) {
   DEBUG("dhcp_rhdl_request(address,config)\n");
 
   time_t now = time(NULL);
@@ -280,7 +280,7 @@ int dhcp_rhdl_request(uint32_t* address, ddhcp_config* config) {
   }
 }
 
-int dhcp_rhdl_ack(int socket, struct dhcp_packet* request, ddhcp_config* config) {
+ATTR_NONNULL_ALL int dhcp_rhdl_ack(int socket, struct dhcp_packet* request, ddhcp_config* config) {
 
   ddhcp_block* lease_block = NULL;
   uint32_t lease_index = 0;
@@ -302,7 +302,7 @@ int dhcp_rhdl_ack(int socket, struct dhcp_packet* request, ddhcp_config* config)
   return dhcp_ack(socket, request, lease_block, lease_index, config);
 }
 
-int dhcp_hdl_request(int socket, struct dhcp_packet* request, ddhcp_config* config) {
+ATTR_NONNULL_ALL int dhcp_hdl_request(int socket, struct dhcp_packet* request, ddhcp_config* config) {
   DEBUG("dhcp_hdl_request(socket:%i, dhcp_packet, config)\n", socket);
 
   // search the lease we may have offered
@@ -445,7 +445,7 @@ int dhcp_hdl_request(int socket, struct dhcp_packet* request, ddhcp_config* conf
   return dhcp_ack(socket, request, lease_block, lease_index, config);
 }
 
-void dhcp_hdl_release(dhcp_packet* packet, ddhcp_config* config) {
+ATTR_NONNULL_ALL void dhcp_hdl_release(dhcp_packet* packet, ddhcp_config* config) {
   DEBUG("dhcp_hdl_release(dhcp_packet,config)\n");
 
   ddhcp_block* lease_block = NULL;
@@ -480,7 +480,7 @@ void dhcp_hdl_release(dhcp_packet* packet, ddhcp_config* config) {
   }
 }
 
-void dhcp_hdl_inform(int socket, dhcp_packet* request, ddhcp_config* config) {
+ATTR_NONNULL_ALL void dhcp_hdl_inform(int socket, dhcp_packet* request, ddhcp_config* config) {
   DEBUG("dhcp_hdl_inform(socket:%i, dhcp_packet,config)\n", socket);
 
   ddhcp_block* lease_block = NULL;
@@ -516,7 +516,7 @@ void dhcp_hdl_inform(int socket, dhcp_packet* request, ddhcp_config* config) {
   free(packet);
 }
 
-int dhcp_nack(int socket, dhcp_packet* from_client, ddhcp_config* config) {
+ATTR_NONNULL_ALL int dhcp_nack(int socket, dhcp_packet* from_client, ddhcp_config* config) {
   dhcp_packet* packet = build_initial_packet(from_client);
 
   if (!packet) {
@@ -550,7 +550,7 @@ int dhcp_nack(int socket, dhcp_packet* from_client, ddhcp_config* config) {
   return 0;
 }
 
-int dhcp_ack(int socket, dhcp_packet* request, ddhcp_block* lease_block, uint32_t lease_index, ddhcp_config* config) {
+ATTR_NONNULL_ALL int dhcp_ack(int socket, dhcp_packet* request, ddhcp_block* lease_block, uint32_t lease_index, ddhcp_config* config) {
   time_t now = time(NULL);
   dhcp_lease* lease = lease_block->addresses + lease_index;
 
@@ -589,7 +589,7 @@ int dhcp_ack(int socket, dhcp_packet* request, ddhcp_block* lease_block, uint32_
   return 0;
 }
 
-int dhcp_has_free(struct ddhcp_block* block) {
+ATTR_NONNULL_ALL int dhcp_has_free(struct ddhcp_block* block) {
   dhcp_lease* lease = block->addresses;
 
   for (unsigned int i = 0; i < block->subnet_len; i++) {
@@ -603,7 +603,7 @@ int dhcp_has_free(struct ddhcp_block* block) {
   return 0;
 }
 
-uint32_t dhcp_num_free(struct ddhcp_block* block) {
+ATTR_NONNULL_ALL uint32_t dhcp_num_free(struct ddhcp_block* block) {
   uint32_t num = 0;
   dhcp_lease* lease = block->addresses;
 
@@ -618,7 +618,7 @@ uint32_t dhcp_num_free(struct ddhcp_block* block) {
   return num;
 }
 
-uint32_t dhcp_num_offered(struct ddhcp_block* block) {
+ATTR_NONNULL_ALL uint32_t dhcp_num_offered(struct ddhcp_block* block) {
   uint32_t num = 0;
   dhcp_lease* lease = block->addresses;
 
@@ -633,7 +633,7 @@ uint32_t dhcp_num_offered(struct ddhcp_block* block) {
   return num;
 }
 
-uint32_t dhcp_get_free_lease(ddhcp_block* block) {
+ATTR_NONNULL_ALL uint32_t dhcp_get_free_lease(ddhcp_block* block) {
   dhcp_lease* lease = block->addresses;
 
   for (uint32_t i = 0 ; i < block->subnet_len ; i++) {
@@ -649,7 +649,7 @@ uint32_t dhcp_get_free_lease(ddhcp_block* block) {
   return block->subnet_len;
 }
 
-void dhcp_release_lease(uint32_t address, ddhcp_config* config) {
+ATTR_NONNULL_ALL void dhcp_release_lease(uint32_t address, ddhcp_config* config) {
 
   ddhcp_block* lease_block = NULL;
   uint32_t lease_index = 0;
@@ -664,7 +664,7 @@ void dhcp_release_lease(uint32_t address, ddhcp_config* config) {
   }
 }
 
-int dhcp_check_timeouts(ddhcp_block* block) {
+ATTR_NONNULL_ALL int dhcp_check_timeouts(ddhcp_block* block) {
   DEBUG("dhcp_check_timeouts(block)\n");
   dhcp_lease* lease = block->addresses;
   time_t now = time(NULL);

--- a/dhcp.h
+++ b/dhcp.h
@@ -10,7 +10,7 @@
 /**
  * DHCP Process Packet
  */
-int dhcp_process(uint8_t* buffer, ssize_t len, ddhcp_config* config);
+ATTR_NONNULL_ALL int dhcp_process(uint8_t* buffer, ssize_t len, ddhcp_config* config);
 
 /**
  * DHCP Discover
@@ -20,59 +20,59 @@ int dhcp_process(uint8_t* buffer, ssize_t len, ddhcp_config* config);
  *
  * In a second step a dhcp_packet is created an send back.
  */
-int dhcp_hdl_discover(int socket, dhcp_packet* discover, ddhcp_config* config);
+ATTR_NONNULL_ALL int dhcp_hdl_discover(int socket, dhcp_packet* discover, ddhcp_config* config);
 
 /**
  * DHCP Request
  * Performs on base of de
  */
-int dhcp_hdl_request(int socket, struct dhcp_packet* request, ddhcp_config* config);
+ATTR_NONNULL_ALL int dhcp_hdl_request(int socket, struct dhcp_packet* request, ddhcp_config* config);
 
 /**
  * DDHCP Remote Request (Renew)
  */
-int dhcp_rhdl_request(uint32_t* address, ddhcp_config* config);
+ATTR_NONNULL_ALL int dhcp_rhdl_request(uint32_t* address, ddhcp_config* config);
 /**
  * DDHCP Remote Answer (Ack)
  */
-int dhcp_rhdl_ack(int socket, struct dhcp_packet* request, ddhcp_config* config);
+ATTR_NONNULL_ALL int dhcp_rhdl_ack(int socket, struct dhcp_packet* request, ddhcp_config* config);
 
 /**
  * DHCP Release
  */
-void dhcp_hdl_release(dhcp_packet* packet, ddhcp_config* config);
+ATTR_NONNULL_ALL void dhcp_hdl_release(dhcp_packet* packet, ddhcp_config* config);
 
 /**
  * DHCP Inform
  */
-void dhcp_hdl_inform(int socket, dhcp_packet* packet, ddhcp_config* config);
+ATTR_NONNULL_ALL void dhcp_hdl_inform(int socket, dhcp_packet* packet, ddhcp_config* config);
 
-int dhcp_nack(int socket, dhcp_packet* from_client, ddhcp_config* config);
-int dhcp_ack(int socket, dhcp_packet* request, ddhcp_block* lease_block, uint32_t lease_index, ddhcp_config* config);
+ATTR_NONNULL_ALL int dhcp_nack(int socket, dhcp_packet* from_client, ddhcp_config* config);
+ATTR_NONNULL_ALL int dhcp_ack(int socket, dhcp_packet* request, ddhcp_block* lease_block, uint32_t lease_index, ddhcp_config* config);
 
 /**
  * DHCP Lease Available
  * Determan iff there is a free lease in block.
  */
-int dhcp_has_free(struct ddhcp_block* block);
+ATTR_NONNULL_ALL int dhcp_has_free(struct ddhcp_block* block);
 
 /**
  * DHCP num Leases Available
  * Enumerate the free leases in a block
  */
-uint32_t dhcp_num_free(struct ddhcp_block* block);
+ATTR_NONNULL_ALL uint32_t dhcp_num_free(struct ddhcp_block* block);
 
 /**
  * Number of leases offered to clients.
  */
-uint32_t dhcp_num_offered(struct ddhcp_block* block);
+ATTR_NONNULL_ALL uint32_t dhcp_num_offered(struct ddhcp_block* block);
 
 /**
  * Find first free lease in lease block and return its index.
  * This function asserts that there is a free lease, otherwise
  * it returns the value of block_subnet_len.
  */
-uint32_t dhcp_get_free_lease(ddhcp_block* block);
+ATTR_NONNULL_ALL uint32_t dhcp_get_free_lease(ddhcp_block* block);
 
 /**
  * Find lease for given address and mark it as free.
@@ -80,12 +80,12 @@ uint32_t dhcp_get_free_lease(ddhcp_block* block);
  * since there is no reply to a dhcp release packet
  * no further internal handling is needed.
  */
-void dhcp_release_lease(uint32_t address, ddhcp_config* config);
+ATTR_NONNULL_ALL void dhcp_release_lease(uint32_t address, ddhcp_config* config);
 
 /**
  * HouseKeeping: Check for timed out leases.
  * Return the number of free leases in the block.
  */
-int dhcp_check_timeouts(ddhcp_block* block);
+ATTR_NONNULL_ALL int dhcp_check_timeouts(ddhcp_block* block);
 
 #endif

--- a/dhcp_options.c
+++ b/dhcp_options.c
@@ -8,7 +8,7 @@
 #include "logger.h"
 #include "tools.h"
 
-dhcp_option* find_option(dhcp_option* options, uint8_t len, uint8_t code) {
+ATTR_NONNULL_ALL dhcp_option* find_option(dhcp_option* options, uint8_t len, uint8_t code) {
   dhcp_option* option = options;
 
   for (; option < options + len; option++) {
@@ -20,7 +20,7 @@ dhcp_option* find_option(dhcp_option* options, uint8_t len, uint8_t code) {
   return NULL;
 }
 
-int set_option(dhcp_option* options, uint8_t len, uint8_t code, uint8_t payload_len, uint8_t* payload) {
+ATTR_NONNULL_ALL int set_option(dhcp_option* options, uint8_t len, uint8_t code, uint8_t payload_len, uint8_t* payload) {
   DEBUG("set_option(options, len:%i, code:%i, payload_len:%i, payload)\n", len, code, payload_len);
 
   for (int i = len - 1; i >= 0; i--) {
@@ -41,7 +41,7 @@ int set_option(dhcp_option* options, uint8_t len, uint8_t code, uint8_t payload_
   return 1;
 }
 
-int set_option_from_store(dhcp_option_list* store, dhcp_option* options, uint8_t len, uint8_t code) {
+ATTR_NONNULL_ALL int set_option_from_store(dhcp_option_list* store, dhcp_option* options, uint8_t len, uint8_t code) {
   dhcp_option* option = find_in_option_store(store, code);
 
   if (!option) {
@@ -52,7 +52,7 @@ int set_option_from_store(dhcp_option_list* store, dhcp_option* options, uint8_t
   return set_option(options, len, code, option->len, option->payload);
 }
 
-int find_option_parameter_request_list(dhcp_option* options, uint8_t len, uint8_t** requested) {
+ATTR_NONNULL(1) int find_option_parameter_request_list(dhcp_option* options, uint8_t len, uint8_t** requested) {
   dhcp_option* option = find_option(options, len, DHCP_CODE_PARAMETER_REQUEST_LIST);
 
   if (requested) {
@@ -67,7 +67,7 @@ int find_option_parameter_request_list(dhcp_option* options, uint8_t len, uint8_
 }
 
 
-uint8_t* find_option_requested_address(dhcp_option* options, uint8_t len) {
+ATTR_NONNULL_ALL uint8_t* find_option_requested_address(dhcp_option* options, uint8_t len) {
   dhcp_option* option = find_option(options, len, DHCP_CODE_REQUESTED_ADDRESS);
 
   DEBUG("find_option_requested_address(...): address %s\n", option ? "found" : "not found");
@@ -75,7 +75,7 @@ uint8_t* find_option_requested_address(dhcp_option* options, uint8_t len) {
   return option ? option->payload : NULL;
 }
 
-dhcp_option* find_in_option_store(dhcp_option_list* options, uint8_t code) {
+ATTR_NONNULL_ALL dhcp_option* find_in_option_store(dhcp_option_list* options, uint8_t code) {
   DEBUG("find_in_option_store(store, code:%i)\n", code);
 
   dhcp_option* option;
@@ -90,7 +90,7 @@ dhcp_option* find_in_option_store(dhcp_option_list* options, uint8_t code) {
   return NULL;
 }
 
-uint32_t find_in_option_store_address_lease_time(dhcp_option_list* options) {
+ATTR_NONNULL_ALL uint32_t find_in_option_store_address_lease_time(dhcp_option_list* options) {
   dhcp_option* lease_time_opt = find_in_option_store(options, DHCP_CODE_ADDRESS_LEASE_TIME);
 
   if (lease_time_opt) {
@@ -108,7 +108,7 @@ uint32_t find_in_option_store_address_lease_time(dhcp_option_list* options) {
   return 0;
 }
 
-dhcp_option* set_option_in_store(dhcp_option_list* store, dhcp_option* option) {
+ATTR_NONNULL_ALL dhcp_option* set_option_in_store(dhcp_option_list* store, dhcp_option* option) {
   DEBUG("set_in_option_store(store, code:%i, len%i)\n", option->code, option->len);
 
   dhcp_option* current = find_in_option_store(store, option->code);
@@ -135,7 +135,7 @@ dhcp_option* set_option_in_store(dhcp_option_list* store, dhcp_option* option) {
   }
 }
 
-void free_option(struct dhcp_option* option) {
+ATTR_NONNULL_ALL void free_option(struct dhcp_option* option) {
   if (option->payload) {
     free(option->payload);
   }
@@ -143,7 +143,7 @@ void free_option(struct dhcp_option* option) {
   free(option);
 }
 
-void remove_option_in_store(dhcp_option_list* store, uint8_t code) {
+ATTR_NONNULL_ALL void remove_option_in_store(dhcp_option_list* store, uint8_t code) {
   dhcp_option* option = find_in_option_store(store, code);
 
   if (option) {
@@ -152,7 +152,7 @@ void remove_option_in_store(dhcp_option_list* store, uint8_t code) {
   }
 }
 
-void free_option_store(dhcp_option_list* store) {
+ATTR_NONNULL_ALL void free_option_store(dhcp_option_list* store) {
   struct list_head* pos, *q;
 
   list_for_each_safe(pos, q, store) {
@@ -162,9 +162,9 @@ void free_option_store(dhcp_option_list* store) {
   }
 }
 
-dhcp_option* remove_option_from_store(dhcp_option_list* store, uint8_t code);
+ATTR_NONNULL_ALL dhcp_option* remove_option_from_store(dhcp_option_list* store, uint8_t code);
 
-int16_t fill_options(dhcp_option* options, uint8_t len, dhcp_option_list* option_store, uint8_t additional, dhcp_option** fullfil) {
+ATTR_NONNULL_ALL int16_t fill_options(dhcp_option* options, uint8_t len, dhcp_option_list* option_store, uint8_t additional, dhcp_option** fullfil) {
   uint8_t num_found_options = 0;
 
   uint8_t* requested = NULL;
@@ -194,7 +194,7 @@ int16_t fill_options(dhcp_option* options, uint8_t len, dhcp_option_list* option
   return (int16_t)(num_found_options + additional);
 }
 
-void dhcp_options_show(int fd, ddhcp_config* config) {
+ATTR_NONNULL_ALL void dhcp_options_show(int fd, ddhcp_config* config) {
   struct dhcp_option* option;
   dhcp_option_list* store = &config->options;
 
@@ -213,7 +213,7 @@ void dhcp_options_show(int fd, ddhcp_config* config) {
   }
 }
 
-int dhcp_options_init(ddhcp_config* config) {
+ATTR_NONNULL_ALL int dhcp_options_init(ddhcp_config* config) {
   dhcp_option* option;
   int8_t pl = (int8_t)config->prefix_len;
 

--- a/dhcp_options.h
+++ b/dhcp_options.h
@@ -7,7 +7,7 @@
  * Search and returns an dhcp_option in a list of options.
  * Returns NULL otherwise.
  */
-dhcp_option* find_option(dhcp_option* options, uint8_t len, uint8_t code);
+ATTR_NONNULL_ALL dhcp_option* find_option(dhcp_option* options, uint8_t len, uint8_t code);
 
 /**
  * Search for the option with searched code and replace payload or search an empty
@@ -15,26 +15,26 @@ dhcp_option* find_option(dhcp_option* options, uint8_t len, uint8_t code);
  * is pointed to the new payload.
  * Return a value greater then 0 on failure or 0 otherwise.
  */
-int set_option(dhcp_option* options, uint8_t len, uint8_t code, uint8_t payload_len, uint8_t* payload);
+ATTR_NONNULL_ALL int set_option(dhcp_option* options, uint8_t len, uint8_t code, uint8_t payload_len, uint8_t* payload);
 
 /**
  * Remove options.
  */
-void remove_option(dhcp_option* options, uint8_t code);
+ATTR_NONNULL_ALL void remove_option(dhcp_option* options, uint8_t code);
 
 /**
  * Search for the parameter request list option in a list of options.
  * On success the requested pointer is set and a positiv integer
  * is returned. Otherwise 0 is returned and requested is pointed to NULL.
  */
-int find_option_parameter_request_list(dhcp_option* options, uint8_t len, uint8_t** requested);
+ATTR_NONNULL(1) int find_option_parameter_request_list(dhcp_option* options, uint8_t len, uint8_t** requested);
 
 /** Search for the requested ip address option in a list of options.
  * On success the pointer to the payload is returned, which should be
  * of length 4. TODO Check this
  * Otherwise the null-pointer is returned.
  */
-uint8_t* find_option_requested_address(dhcp_option* options, uint8_t len);
+ATTR_NONNULL_ALL uint8_t* find_option_requested_address(dhcp_option* options, uint8_t len);
 
 /**
  * First searches the parameter request list in the given options list.
@@ -44,17 +44,17 @@ uint8_t* find_option_requested_address(dhcp_option* options, uint8_t len);
  *
  * Caller must handle memory deallocation.
  */
-int16_t fill_options(dhcp_option* options, uint8_t len, dhcp_option_list* option_store, uint8_t additional, dhcp_option** fullfil);
+ATTR_NONNULL_ALL int16_t fill_options(dhcp_option* options, uint8_t len, dhcp_option_list* option_store, uint8_t additional, dhcp_option** fullfil);
 
 /**
  * Search and Retrun a option in an option store. Return null otherwise.
  */
-dhcp_option* find_in_option_store(dhcp_option_list* options, uint8_t code);
+ATTR_NONNULL_ALL dhcp_option* find_in_option_store(dhcp_option_list* options, uint8_t code);
 
 /**
  * Search and return leasetime option
  */
-uint32_t find_in_option_store_address_lease_time(dhcp_option_list* options);
+ATTR_NONNULL_ALL uint32_t find_in_option_store_address_lease_time(dhcp_option_list* options);
 
 /**
  * Is a option defined in a option store
@@ -64,30 +64,31 @@ uint32_t find_in_option_store_address_lease_time(dhcp_option_list* options);
 /**
  * Search and replace a option in the store, otherwise append it to the store.
  */
-dhcp_option* set_option_in_store(dhcp_option_list* store, dhcp_option* option);
+ATTR_NONNULL_ALL dhcp_option* set_option_in_store(dhcp_option_list* store, dhcp_option* option);
 
 /**
  * Search and remove a option in the store.
  */
-void remove_option_in_store(dhcp_option_list* store, uint8_t code);
+ATTR_NONNULL_ALL void remove_option_in_store(dhcp_option_list* store, uint8_t code);
 
 /**
  * Free option store and all contained dhcp_options.
  */
-void free_option_store(dhcp_option_list* store);
+ATTR_NONNULL_ALL void free_option_store(dhcp_option_list* store);
 
 /**
  * Print the inventory of a option store into given file descriptor.
  */
-void dhcp_options_show(int fd, ddhcp_config* config);
+ATTR_NONNULL_ALL void dhcp_options_show(int fd, ddhcp_config* config);
 
 /**
  * Initialize dhcp_options store in the configuration.
  */
-int dhcp_options_init(ddhcp_config* config);
+ATTR_NONNULL_ALL int dhcp_options_init(ddhcp_config* config);
 
 /**
  * Search for option in store and if found store it in the options list.
  */
-int set_option_from_store(dhcp_option_list* store, dhcp_option* options, uint8_t len, uint8_t code);
+ATTR_NONNULL_ALL int set_option_from_store(dhcp_option_list* store, dhcp_option* options, uint8_t len, uint8_t code);
+
 #endif

--- a/dhcp_packet.c
+++ b/dhcp_packet.c
@@ -19,7 +19,7 @@ struct sockaddr_in unicast = {
 
 
 #if LOG_LEVEL_LIMIT >= LOG_DEBUG
-void printf_dhcp(dhcp_packet* packet) {
+ATTR_NONNULL_ALL void printf_dhcp(dhcp_packet* packet) {
   char tmpstr[INET_ADDRSTRLEN];
 
   inet_ntop(AF_INET, &(packet->ciaddr.s_addr), tmpstr, INET_ADDRSTRLEN);
@@ -71,7 +71,7 @@ void printf_dhcp(dhcp_packet* packet) {
 #define printf_dhcp(packet) {}
 # endif
 
-size_t _dhcp_packet_len(dhcp_packet* packet) {
+ATTR_NONNULL_ALL size_t _dhcp_packet_len(dhcp_packet* packet) {
   size_t len = 240 + 1;
   dhcp_option* option = packet->options;
 
@@ -93,7 +93,7 @@ size_t _dhcp_packet_len(dhcp_packet* packet) {
   return len;
 }
 
-ssize_t ntoh_dhcp_packet(dhcp_packet* packet, uint8_t* buffer, ssize_t len) {
+ATTR_NONNULL_ALL ssize_t ntoh_dhcp_packet(dhcp_packet* packet, uint8_t* buffer, ssize_t len) {
 
   uint16_t tmp16;
   uint32_t tmp32;
@@ -242,7 +242,7 @@ ssize_t ntoh_dhcp_packet(dhcp_packet* packet, uint8_t* buffer, ssize_t len) {
   return 0;
 }
 
-ssize_t dhcp_packet_send(int socket, dhcp_packet* packet) {
+ATTR_NONNULL_ALL ssize_t dhcp_packet_send(int socket, dhcp_packet* packet) {
   DEBUG("dhcp_packet_send(socket:%i, dhcp_packet)\n", socket);
   uint16_t tmp16;
   uint32_t tmp32;
@@ -333,7 +333,7 @@ ssize_t dhcp_packet_send(int socket, dhcp_packet* packet) {
   return bytes_send;
 }
 
-int dhcp_packet_copy(dhcp_packet* dest, dhcp_packet* src) {
+ATTR_NONNULL_ALL int dhcp_packet_copy(dhcp_packet* dest, dhcp_packet* src) {
   int err;
 
   memcpy(dest, src, sizeof(struct dhcp_packet));
@@ -373,7 +373,7 @@ fail_options:
   return err;
 }
 
-int dhcp_packet_list_add(dhcp_packet_list* list, dhcp_packet* packet) {
+ATTR_NONNULL_ALL int dhcp_packet_list_add(dhcp_packet_list* list, dhcp_packet* packet) {
   time_t now = time(NULL);
   // Save dhcp packet, for further actions, later.
   dhcp_packet* copy = calloc(1, sizeof(dhcp_packet));
@@ -389,7 +389,7 @@ int dhcp_packet_list_add(dhcp_packet_list* list, dhcp_packet* packet) {
   return 0;
 }
 
-dhcp_packet* dhcp_packet_list_find(dhcp_packet_list* list, uint32_t xid, uint8_t* chaddr) {
+ATTR_NONNULL_ALL dhcp_packet* dhcp_packet_list_find(dhcp_packet_list* list, uint32_t xid, uint8_t* chaddr) {
   DEBUG("dhcp_packet_list_find(list,xid:%u,chaddr)\n", xid);
   struct list_head* pos, *q;
 
@@ -412,7 +412,7 @@ dhcp_packet* dhcp_packet_list_find(dhcp_packet_list* list, uint32_t xid, uint8_t
   return NULL;
 }
 
-void dhcp_packet_list_free(dhcp_packet_list* list) {
+ATTR_NONNULL_ALL void dhcp_packet_list_free(dhcp_packet_list* list) {
   DEBUG("dhcp_packet_list_free(list)\n");
   struct list_head* pos, *q;
 
@@ -424,7 +424,7 @@ void dhcp_packet_list_free(dhcp_packet_list* list) {
   }
 }
 
-uint8_t dhcp_packet_message_type(dhcp_packet* packet) {
+ATTR_NONNULL_ALL uint8_t dhcp_packet_message_type(dhcp_packet* packet) {
   dhcp_option* option = packet->options;
 
   for (int i = 0; i < packet->options_len; i++) {
@@ -438,7 +438,7 @@ uint8_t dhcp_packet_message_type(dhcp_packet* packet) {
   return 0;
 }
 
-void dhcp_packet_list_timeout(dhcp_packet_list* list) {
+ATTR_NONNULL_ALL void dhcp_packet_list_timeout(dhcp_packet_list* list) {
   DEBUG("dhcp_packet_list_timeout(list)\n");
   struct list_head* pos, *q;
   time_t now = time(NULL);

--- a/dhcp_packet.h
+++ b/dhcp_packet.h
@@ -48,32 +48,32 @@ enum dhcp_message_type {
 /**
  * Store a packet in the packet_list, create a copy of the packet.
  */
-int dhcp_packet_list_add(dhcp_packet_list* list, dhcp_packet* packet);
+ATTR_NONNULL_ALL int dhcp_packet_list_add(dhcp_packet_list* list, dhcp_packet* packet);
 
 /**
  * Search for a packet in the dhcp_packet_list checking chaddr and xid.
  */
-dhcp_packet* dhcp_packet_list_find(dhcp_packet_list* list, uint32_t xid, uint8_t* chaddr);
+ATTR_NONNULL_ALL dhcp_packet* dhcp_packet_list_find(dhcp_packet_list* list, uint32_t xid, uint8_t* chaddr);
 
 /**
  * Cleanup the packet list.
  */
-void dhcp_packet_list_timeout(dhcp_packet_list* list);
+ATTR_NONNULL_ALL void dhcp_packet_list_timeout(dhcp_packet_list* list);
 
 /**
  * Free DHCP packet list
  */
-void dhcp_packet_list_free(dhcp_packet_list* list);
+ATTR_NONNULL_ALL void dhcp_packet_list_free(dhcp_packet_list* list);
 
 /**
  * Print an representation of a dhcp_packet to stdout.
  */
-void printf_dhcp(dhcp_packet* packet);
+ATTR_NONNULL_ALL void printf_dhcp(dhcp_packet* packet);
 
 /**
  * Memcpy a packet into another packet.
  */
-int dhcp_packet_copy(dhcp_packet* dest, dhcp_packet* src);
+ATTR_NONNULL_ALL int dhcp_packet_copy(dhcp_packet* dest, dhcp_packet* src);
 
 
 /**
@@ -95,8 +95,9 @@ int dhcp_packet_copy(dhcp_packet* dest, dhcp_packet* src);
  * make pointer to the buffer inside of the dhcp_packet structure. Do not free
  * the buffer before the last operation on that struture!
  */
-ssize_t ntoh_dhcp_packet(dhcp_packet* packet, uint8_t* buffer, ssize_t len);
-ssize_t dhcp_packet_send(int socket, dhcp_packet* packet);
+ATTR_NONNULL_ALL ssize_t ntoh_dhcp_packet(dhcp_packet* packet, uint8_t* buffer, ssize_t len);
+ATTR_NONNULL_ALL ssize_t dhcp_packet_send(int socket, dhcp_packet* packet);
 
-uint8_t dhcp_packet_message_type(dhcp_packet* packet);
+ATTR_NONNULL_ALL uint8_t dhcp_packet_message_type(dhcp_packet* packet);
+
 #endif

--- a/hook.c
+++ b/hook.c
@@ -6,7 +6,7 @@
 #include <sys/types.h>
 #include <sys/wait.h>
 
-void hook(uint8_t type, struct in_addr* address, uint8_t* chaddr, ddhcp_config* config) {
+ATTR_NONNULL_ALL void hook(uint8_t type, struct in_addr* address, uint8_t* chaddr, ddhcp_config* config) {
 #if LOG_LEVEL_LIMIT >= LOG_DEBUG
   char* hwaddr = hwaddr2c(chaddr);
   DEBUG("hook(type:%i,addr:%s,chaddr:%s,config)\n", type, inet_ntoa(*address), hwaddr);

--- a/hook.h
+++ b/hook.h
@@ -7,7 +7,7 @@
 #define HOOK_RELEASE 2
 #define HOOK_INFORM 3
 
-void hook(uint8_t type, struct in_addr* address, uint8_t* chaddr, ddhcp_config* config);
+ATTR_NONNULL_ALL void hook(uint8_t type, struct in_addr* address, uint8_t* chaddr, ddhcp_config* config);
 void hook_init();
 
 #endif

--- a/list.h
+++ b/list.h
@@ -32,6 +32,8 @@
 #include <stddef.h>
 #include <stdbool.h>
 
+#include "types.h"
+
 #define	prefetch(x)
 
 #ifndef container_of
@@ -51,47 +53,47 @@ struct list_head {
 #undef LIST_HEAD
 #define LIST_HEAD(name)	struct list_head name = LIST_HEAD_INIT(name)
 
-static inline void
+static inline ATTR_NONNULL_ALL void
 INIT_LIST_HEAD(struct list_head* list)
 {
   list->next = list->prev = list;
 }
 
-static inline bool
+static inline ATTR_NONNULL_ALL bool
 list_empty(const struct list_head* head)
 {
   return (head->next == head);
 }
 
-static inline bool
+static inline ATTR_NONNULL_ALL bool
 list_is_first(const struct list_head* list,
               const struct list_head* head)
 {
   return list->prev == head;
 }
 
-static inline bool
+static inline ATTR_NONNULL_ALL bool
 list_is_last(const struct list_head* list,
              const struct list_head* head)
 {
   return list->next == head;
 }
 
-static inline void
+static inline ATTR_NONNULL_ALL void
 _list_del(struct list_head* entry)
 {
   entry->next->prev = entry->prev;
   entry->prev->next = entry->next;
 }
 
-static inline void
+static inline ATTR_NONNULL_ALL void
 list_del(struct list_head* entry)
 {
   _list_del(entry);
   entry->next = entry->prev = NULL;
 }
 
-static inline void
+static inline ATTR_NONNULL_ALL void
 _list_add(struct list_head* _new, struct list_head* prev,
           struct list_head* next)
 {
@@ -102,7 +104,7 @@ _list_add(struct list_head* _new, struct list_head* prev,
   prev->next = _new;
 }
 
-static inline void
+static inline ATTR_NONNULL_ALL void
 list_del_init(struct list_head* entry)
 {
   _list_del(entry);
@@ -135,33 +137,33 @@ list_del_init(struct list_head* entry)
 #define	list_for_each_prev(p, h) for (p = (h)->prev; p != (h); p = p->prev)
 #define	list_for_each_prev_safe(p, n, h) for (p = (h)->prev, n = p->prev; p != (h); p = n, n = p->prev)
 
-static inline void
+static inline ATTR_NONNULL_ALL void
 list_add(struct list_head* _new, struct list_head* head)
 {
   _list_add(_new, head, head->next);
 }
 
-static inline void
+static inline ATTR_NONNULL_ALL void
 list_add_tail(struct list_head* _new, struct list_head* head)
 {
   _list_add(_new, head->prev, head);
 }
 
-static inline void
+static inline ATTR_NONNULL_ALL void
 list_move(struct list_head* list, struct list_head* head)
 {
   _list_del(list);
   list_add(list, head);
 }
 
-static inline void
+static inline ATTR_NONNULL_ALL void
 list_move_tail(struct list_head* entry, struct list_head* head)
 {
   _list_del(entry);
   list_add_tail(entry, head);
 }
 
-static inline void
+static inline ATTR_NONNULL_ALL void
 _list_splice(const struct list_head* list, struct list_head* prev,
              struct list_head* next)
 {
@@ -180,26 +182,26 @@ _list_splice(const struct list_head* list, struct list_head* prev,
   next->prev = last;
 }
 
-static inline void
+static inline ATTR_NONNULL_ALL void
 list_splice(const struct list_head* list, struct list_head* head)
 {
   _list_splice(list, head, head->next);
 }
 
-static inline void
+static inline ATTR_NONNULL_ALL void
 list_splice_tail(struct list_head* list, struct list_head* head)
 {
   _list_splice(list, head->prev, head);
 }
 
-static inline void
+static inline ATTR_NONNULL_ALL void
 list_splice_init(struct list_head* list, struct list_head* head)
 {
   _list_splice(list, head, head->next);
   INIT_LIST_HEAD(list);
 }
 
-static inline void
+static inline ATTR_NONNULL_ALL void
 list_splice_tail_init(struct list_head* list, struct list_head* head)
 {
   _list_splice(list, head->prev, head);

--- a/logger.c
+++ b/logger.c
@@ -4,7 +4,7 @@
 
 int log_level = LOG_LEVEL_DEFAULT;
 
-void logger(int level, const char* prefix, ...) {
+ATTR_NONNULL_ALL void logger(int level, const char* prefix, ...) {
   if (log_level >= level) {
     va_list args;
     char* fmt;

--- a/logger.h
+++ b/logger.h
@@ -7,6 +7,8 @@
 
 #include <stdio.h>
 
+#include "types.h"
+
 #define LOG_FATAL 0
 #define LOG_ERROR 1
 #define LOG_WARNING 2
@@ -25,7 +27,7 @@
 
 #define HEX_NODE_ID(x) ((uint8_t*) x)[0],((uint8_t*) x)[1],((uint8_t*) x)[2],((uint8_t*) x)[3],((uint8_t*) x)[4],((uint8_t*) x)[5],((uint8_t*) x)[6],((uint8_t*) x)[7]
 
-void logger(int level, const char* prefix, ...);
+ATTR_NONNULL_ALL void logger(int level, const char* prefix, ...);
 
 #define LOG(...) logger(-1, "",__VA_ARGS__)
 

--- a/main.c
+++ b/main.c
@@ -34,7 +34,7 @@ extern int log_level;
 const int NET = 0;
 const int NET_LEN = 10;
 
-in_addr_storage get_in_addr(struct sockaddr* sa)
+ATTR_NONNULL_ALL in_addr_storage get_in_addr(struct sockaddr* sa)
 {
   struct sockaddr_in in;
   struct sockaddr_in6 in6;
@@ -59,7 +59,7 @@ in_addr_storage get_in_addr(struct sockaddr* sa)
  * + Claim new blocks if we are low on spare leases.
  * + Update our claims.
  */
-void house_keeping(ddhcp_config* config) {
+ATTR_NONNULL_ALL void house_keeping(ddhcp_config* config) {
   DEBUG("house_keeping(blocks,config)\n");
   block_check_timeouts(config);
 
@@ -115,7 +115,7 @@ void del_fd(int efd, int fd, uint32_t events) {
   }
 }
 
-uint32_t get_loop_timeout(ddhcp_config* config) {
+ATTR_NONNULL_ALL uint32_t get_loop_timeout(ddhcp_config* config) {
   //Multiply by 500 to convert the timeout value given in seconds
   //into milliseconds AND dividing the value by two at the same time.
   //The integer overflow occuring for timeouts greater than 99.4 days is ignored here.

--- a/netsock.c
+++ b/netsock.c
@@ -52,7 +52,7 @@ const struct in6_addr in6addr_localmcast =
   }
 };
 
-int mac_to_ipv6(const struct ether_addr* mac, struct in6_addr* addr)
+ATTR_NONNULL_ALL int mac_to_ipv6(const struct ether_addr* mac, struct in6_addr* addr)
 {
   memset(addr, 0, sizeof(*addr));
   addr->s6_addr[0] = 0xfe;
@@ -72,7 +72,7 @@ int mac_to_ipv6(const struct ether_addr* mac, struct in6_addr* addr)
   return 0;
 }
 
-int control_open(ddhcp_config* state) {
+ATTR_NONNULL_ALL int control_open(ddhcp_config* state) {
   int ctl_sock;
   struct sockaddr_un s_un;
   int ret;
@@ -112,9 +112,9 @@ err:
   return -1;
 }
 
-int netsock_openv4(char* interface_client, ddhcp_config* config);
+ATTR_NONNULL_ALL int netsock_openv4(char* interface_client, ddhcp_config* config);
 
-int netsock_open(char* interface, char* interface_client, ddhcp_config* state)
+ATTR_NONNULL_ALL int netsock_open(char* interface, char* interface_client, ddhcp_config* state)
 {
   int sock_mc;
   int sock_srv;
@@ -286,7 +286,7 @@ err_nomc:
   return -1;
 }
 
-int netsock_openv4(char* interface_client, ddhcp_config* config) {
+ATTR_NONNULL_ALL int netsock_openv4(char* interface_client, ddhcp_config* config) {
   int sock;
   struct sockaddr_in sin;
   struct in_addr address_client;

--- a/netsock.h
+++ b/netsock.h
@@ -8,8 +8,8 @@
 
 const struct in6_addr in6addr_localmast;
 
-int control_open(ddhcp_config* state);
-int control_connect(ddhcp_config* state);
-int netsock_open(char* interface, char* interface_client, ddhcp_config* state);
+ATTR_NONNULL_ALL int control_open(ddhcp_config* state);
+ATTR_NONNULL_ALL int control_connect(ddhcp_config* state);
+ATTR_NONNULL_ALL int netsock_open(char* interface, char* interface_client, ddhcp_config* state);
 
 #endif

--- a/packet.c
+++ b/packet.c
@@ -54,7 +54,7 @@ ssize_t _packet_size(uint8_t command, ssize_t payload_count) {
   return len;
 }
 
-struct ddhcp_mcast_packet* new_ddhcp_packet(uint8_t command, ddhcp_config* config) {
+ATTR_NONNULL_ALL struct ddhcp_mcast_packet* new_ddhcp_packet(uint8_t command, ddhcp_config* config) {
   struct ddhcp_mcast_packet* packet = (struct ddhcp_mcast_packet*) calloc(sizeof(struct ddhcp_mcast_packet), 1);
 
   if (!packet) {
@@ -72,7 +72,7 @@ struct ddhcp_mcast_packet* new_ddhcp_packet(uint8_t command, ddhcp_config* confi
   return packet;
 }
 
-ssize_t ntoh_mcast_packet(uint8_t* buffer, ssize_t len, struct ddhcp_mcast_packet* packet) {
+ATTR_NONNULL_ALL ssize_t ntoh_mcast_packet(uint8_t* buffer, ssize_t len, struct ddhcp_mcast_packet* packet) {
 
   // Header
   copy_buf_to_var_inc(buffer, ddhcp_node_id, packet->node_id);
@@ -188,7 +188,7 @@ ssize_t ntoh_mcast_packet(uint8_t* buffer, ssize_t len, struct ddhcp_mcast_packe
   return 0;
 }
 
-int hton_packet(struct ddhcp_mcast_packet* packet, char* buffer) {
+ATTR_NONNULL_ALL int hton_packet(struct ddhcp_mcast_packet* packet, char* buffer) {
 
   // Header
   copy_var_to_buf_inc(buffer, ddhcp_node_id, packet->node_id);
@@ -263,7 +263,7 @@ int hton_packet(struct ddhcp_mcast_packet* packet, char* buffer) {
   return 0;
 }
 
-ssize_t send_packet_mcast(struct ddhcp_mcast_packet* packet, int mulitcast_socket, uint32_t scope_id) {
+ATTR_NONNULL_ALL ssize_t send_packet_mcast(struct ddhcp_mcast_packet* packet, int mulitcast_socket, uint32_t scope_id) {
   size_t len = (size_t)_packet_size(packet->command, packet->count);
 
   char* buffer = (char*) calloc(1, len);
@@ -295,7 +295,7 @@ ssize_t send_packet_mcast(struct ddhcp_mcast_packet* packet, int mulitcast_socke
   return bytes_send;
 }
 
-ssize_t send_packet_direct(struct ddhcp_mcast_packet* packet, struct in6_addr* dest, int multicast_socket, uint32_t scope_id) {
+ATTR_NONNULL_ALL ssize_t send_packet_direct(struct ddhcp_mcast_packet* packet, struct in6_addr* dest, int multicast_socket, uint32_t scope_id) {
   DEBUG("send_packet_direct(packet,dest,mcsocket:%i,scope:%u)\n", multicast_socket, scope_id);
   size_t len = (size_t)_packet_size(packet->command, packet->count);
 

--- a/packet.h
+++ b/packet.h
@@ -62,10 +62,10 @@ struct ddhcp_renew_payload {
 };
 typedef struct ddhcp_renew_payload ddhcp_renew_payload;
 
-struct ddhcp_mcast_packet* new_ddhcp_packet(uint8_t command, ddhcp_config* config);
-ssize_t ntoh_mcast_packet(uint8_t* buffer, ssize_t len, struct ddhcp_mcast_packet* packet);
+ATTR_NONNULL_ALL struct ddhcp_mcast_packet* new_ddhcp_packet(uint8_t command, ddhcp_config* config);
+ATTR_NONNULL_ALL ssize_t ntoh_mcast_packet(uint8_t* buffer, ssize_t len, struct ddhcp_mcast_packet* packet);
 
-ssize_t send_packet_mcast(struct ddhcp_mcast_packet* packet, int mulitcast_socket, uint32_t scope_id);
-ssize_t send_packet_direct(struct ddhcp_mcast_packet* packet, struct in6_addr* dest, int multicast_socket, uint32_t scope_id);
+ATTR_NONNULL_ALL ssize_t send_packet_mcast(struct ddhcp_mcast_packet* packet, int mulitcast_socket, uint32_t scope_id);
+ATTR_NONNULL_ALL ssize_t send_packet_direct(struct ddhcp_mcast_packet* packet, struct in6_addr* dest, int multicast_socket, uint32_t scope_id);
 
 #endif

--- a/statistics.c
+++ b/statistics.c
@@ -3,8 +3,7 @@
 
 #ifdef DDHCPD_STATISTICS
 
-
-void statistics_show(int fd, uint8_t reset, ddhcp_config* config) {
+ATTR_NONNULL_ALL void statistics_show(int fd, uint8_t reset, ddhcp_config* config) {
   dprintf(fd, "mcast.recv_pkg %li\n", config->statistics[STAT_MCAST_RECV_PKG]);
   dprintf(fd, "mcast.send_pkg %li\n", config->statistics[STAT_MCAST_SEND_PKG]);
   dprintf(fd, "mcast.recv_byte %li\n", config->statistics[STAT_MCAST_RECV_BYTE]);
@@ -77,4 +76,5 @@ void statistics_show(int fd, uint8_t reset, ddhcp_config* config) {
     memset(config->statistics, 0, sizeof(long int) * STAT_NUM_OF_FIELDS);
   }
 }
+
 #endif

--- a/statistics.h
+++ b/statistics.h
@@ -5,7 +5,7 @@
 
 #ifdef DDHCPD_STATISTICS
 #define statistics_record(config,type,count) do{(config)->statistics[type]+=count;}while(0)
-void statistics_show(int socket, uint8_t reset, ddhcp_config* config);
+ATTR_NONNULL_ALL void statistics_show(int socket, uint8_t reset, ddhcp_config* config);
 #else
 #define statistics_record(...)
 #define statistics_show(...)

--- a/tools.c
+++ b/tools.c
@@ -7,8 +7,7 @@
 #include <netinet/in.h>
 #include <stdlib.h>
 
-
-void addr_add(struct in_addr* subnet, struct in_addr* result, int add) {
+ATTR_NONNULL_ALL void addr_add(struct in_addr* subnet, struct in_addr* result, int add) {
   struct in_addr addr;
   memcpy(&addr, subnet, sizeof(struct in_addr));
   addr.s_addr = ntohl(addr.s_addr);
@@ -79,7 +78,7 @@ dhcp_option* parse_option() {
   return option;
 }
 
-char* hwaddr2c(uint8_t* hwaddr) {
+ATTR_NONNULL_ALL char* hwaddr2c(uint8_t* hwaddr) {
   char* str = calloc(18, sizeof(char));
 
   if (!str) {

--- a/tools.h
+++ b/tools.h
@@ -9,8 +9,8 @@
 #define max(a,b) (((a)>(b))?(a):(b))
 #define UNUSED(x) (void)(x)
 
-void addr_add(struct in_addr* subnet, struct in_addr* result, int add);
+ATTR_NONNULL_ALL void addr_add(struct in_addr* subnet, struct in_addr* result, int add);
 dhcp_option* parse_option();
-char* hwaddr2c(uint8_t* hwaddr);
+ATTR_NONNULL_ALL char* hwaddr2c(uint8_t* hwaddr);
 
 #endif

--- a/types.h
+++ b/types.h
@@ -4,6 +4,9 @@
 #include <arpa/inet.h>
 #include <time.h>
 
+#define ATTR_NONNULL_ALL __attribute__((nonnull))
+#define ATTR_NONNULL(...) __attribute__((nonnull( __VA_ARGS__ )))
+
 #include "list.h"
 #include "dhcp_packet.h"
 


### PR DESCRIPTION
This is an in-depth optimization providing the compiler with information that arguments are assumed non-NULL when a function is called. This allows to skip the checks in the actual source as long as there are proper checks maintained to ensure valid points for all callers. If a caller lacks such a check that call site will be warned of by the compiler.