### PR TITLE
Fix build for openwrt

### DIFF
--- a/netlink.c
+++ b/netlink.c
@@ -2,6 +2,7 @@
 #include <netlink/msg.h>
 #include <netlink/netlink.h>
 #include <netlink/socket.h>
+#include <linux/rtnetlink.h>
 
 #include "epoll.h"
 #include "logger.h"


### PR DESCRIPTION
This allows to build current ddhcpd with libnl-tiny for openwrt.
